### PR TITLE
Switch deploy-main job from GitHub Pages to Vercel

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -43,6 +43,9 @@ jobs:
 
   deploy-main:
     runs-on: ubuntu-latest
+    env:
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
 
@@ -53,11 +56,5 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run build -- --base=/codjiflo/main/  --sourcemap
-
-      - uses: peaceiris/actions-gh-pages@v4
-        with:
-          personal_token: ${{ secrets.PAGES_DEPLOY_TOKEN }}
-          external_repository: pedropaulovc/pedropaulovc.github.io
-          publish_dir: ./dist
-          destination_dir: codjiflo/main
+      - name: Deploy to Vercel (Production)
+        run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} --meta gitCommitSha=${{ github.sha }}


### PR DESCRIPTION
## Summary
- Replace GitHub Pages deployment with Vercel CLI
- Use `--prod` flag for production deployments
- Reuse existing Vercel secrets from PR workflow

## Test plan
- [ ] Verify workflow runs successfully on merge to main
- [ ] Confirm production deployment appears at configured Vercel domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)