### PR TITLE
Add PR path to preview deployment URL

### DIFF
--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -169,7 +169,7 @@ jobs:
           body: |
             ## Preview Deployment
 
-            :rocket: **Preview:** https://pr-${{ github.event.pull_request.number }}.codjiflo.vza.net
+            :rocket: **Preview:** https://pr-${{ github.event.pull_request.number }}.codjiflo.vza.net/${{ github.repository }}/${{ github.event.pull_request.number }}
 
             _Updated for commit ${{ github.event.pull_request.head.sha }}_
           edit-mode: replace


### PR DESCRIPTION
## Summary
- Preview deployment links now include the full PR path (`/owner/repo/number`)
- Clicking the preview link opens directly to the PR being reviewed instead of the dashboard

## Test plan
- [ ] Merge and verify next PR gets a preview comment with the full path in the URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)