### PR TITLE
Add Janitor workflow for automated codebase improvements

### DIFF
--- a/.github/workflows/janitor.yml
+++ b/.github/workflows/janitor.yml
@@ -200,24 +200,34 @@ jobs:
 
             const janitorLabelId = createIssueQuery.repository.labels.nodes[0]?.id;
 
-            const issueResult = await github.graphql(`
-              mutation CreateIssue($input: CreateIssueInput!) {
-                createIssue(input: $input) {
-                  issue {
-                    number
-                    url
-                    title
-                  }
+            const response = await github.request('POST /graphql', {
+              query: undefined,
+              persistedQueryName: 'createIssueMutation',
+              variables: {
+                fetchParent: false,
+                input: {
+                  repositoryId: repositoryId,
+                  title: title,
+                  body: body,
+                  assigneeIds: [botId],
+                  copilotAssignment: {
+                    baseRef: "main",
+                    customInstructions: "",
+                    model: "claude-opus-4.5",
+                    targetRepositoryId: repositoryId
+                  },
+                  isDuplicated: false,
+                  issueFields: null,
+                  issueTypeId: null,
+                  parentIssueId: null
                 }
               }
-            `, {
-              input: {
-                repositoryId: repositoryId,
-                title: title,
-                body: body,
-                labelIds: janitorLabelId ? [janitorLabelId] : [],
-                assigneeIds: [botId]
-              }
             });
+
+            if (response.data?.errors) {
+              throw new Error(`GraphQL errors: ${JSON.stringify(response.data.errors)}`);
+            }
+
+            const issueResult = response.data?.data;
 
             core.info(`Created issue #${issueResult.createIssue.issue.number}: ${title}`);


### PR DESCRIPTION
## Summary

Implement a daily GitHub workflow that creates janitor tasks to improve code quality without affecting behavior.

- Runs on schedule (daily 2pm UTC) or manual trigger with optional task index
- Rotates through 15 different improvement task types  
- Creates GitHub issues assigned to copilot-swe-agent bot
- Uses GraphQL persisted queries with copilotAssignment

## Implementation

- Parses 15 janitor tasks from YAML environment variable
- Calculates task index by day of year: (dayOfYear - 1) % numTasks
- Queries repository ID and bot ID via GraphQL
- Uses `github.request('POST /graphql')` with persisted query mechanism
- Includes copilotAssignment with model claude-opus-4.5, baseRef main
- Throws error if copilot-swe-agent bot cannot be found

## Features

15 janitor tasks for continuous codebase improvement:
1. Improve code coverage
2. Remove unused dependencies
3. Refactor duplicated code
4. Improve error handling
5. Update code comments
6. Remove dead code
7. Update logging
8. Optimize performance
9. Review folder structure
10. Strengthen existing tests
11. Streamline E2E tests
12. Add missing E2E tests
13. Review spec/functional
14. Review spec/milestones
15. Add/update folder README
16. Update root README.md and AGENTS.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)