### PR TITLE
Fix janitor workflow to use standard GraphQL mutation with model selection

### DIFF
--- a/.github/workflows/janitor.yml
+++ b/.github/workflows/janitor.yml
@@ -230,7 +230,7 @@ jobs:
                 agentAssignment: {
                   targetRepositoryId: repositoryId,
                   baseRef: "main",
-                  model: '${{ github.event.inputs.model }}' || 'claude-opus-4.5'
+                  model: '${{ github.event.inputs.model || 'claude-opus-4.5' }}'
                 }
               },
               headers: {


### PR DESCRIPTION
## Summary
- Replace broken persisted query with standard `github.graphql()` mutation
- Add configurable model selection via workflow dispatch input (defaults to `claude-opus-4.5`)
- Include janitor label on created issues
- Use `agentAssignment` input with required GraphQL-Features header

## Test plan
- [x] Tested locally with `test-janitor.mjs` - successfully created issue #68 with claude-opus-4.5
- [ ] Verify workflow dispatch works from GitHub Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)