### PR TITLE
Change janitor workflow to run every 3 days

### DIFF
--- a/.github/workflows/janitor.yml
+++ b/.github/workflows/janitor.yml
@@ -2,7 +2,7 @@ name: Janitor
 
 on:
   schedule:
-    - cron: '0 14 * * *' # 2pm UTC (6am PST, 7am PDT) daily
+    - cron: '0 14 */3 * *' # 2pm UTC (6am PST, 7am PDT) every 3 days
 
   workflow_dispatch:
     inputs:
@@ -146,7 +146,10 @@ jobs:
               const oneDay = 1000 * 60 * 60 * 24;
               const dayOfYear = Math.floor(diff / oneDay) + 1;
 
-              taskIndex = (dayOfYear - 1) % tasks.length;
+              // With 3-day schedule, divide by 3 to get run number for even task rotation
+              // Full cycle = 16 tasks × 3 days = 48 days
+              const runNumber = Math.floor((dayOfYear - 1) / 3);
+              taskIndex = runNumber % tasks.length;
             }
 
             // Query for repository ID and bot ID


### PR DESCRIPTION
## Summary
- Update cron schedule from daily (`0 14 * * *`) to every 3 days (`0 14 */3 * *`)
- Fix task rotation math to ensure even distribution across all 16 tasks
- Full rotation cycle: 48 days (16 tasks × 3 days each)

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Manual trigger with `task_index` input still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)