### PR TITLE
Fix side-by-side diff view rendering vertically instead of horizontally

### DIFF
--- a/e2e/diff-views.spec.ts
+++ b/e2e/diff-views.spec.ts
@@ -389,6 +389,62 @@ const baz = 'qux';
     }
   });
 
+  test("Side-by-side view renders panes horizontally (S-3.2)", async ({
+    page,
+  }) => {
+    const config = getTestConfig();
+    await page.goto(config.pageUrl);
+    await page.waitForLoadState("networkidle");
+
+    const fileNav = page.getByRole("navigation", { name: /Changed files/i });
+    await expect(fileNav).toBeVisible();
+
+    if (isMockMode()) {
+      await fileNav.getByText("src/example.ts").click();
+      await expect(
+        page.getByRole("heading", { name: "src/example.ts" })
+      ).toBeVisible();
+
+      // Switch to Split view
+      const viewModeGroup = page.getByRole("group", { name: "View mode" });
+      await expect(viewModeGroup).toBeVisible();
+      await viewModeGroup.getByRole("button", { name: /Split/i }).click();
+
+      // Get the side-by-side container and panes
+      const sideBySideContainer = page.getByRole("region", {
+        name: "Side-by-side diff view",
+      });
+      await expect(sideBySideContainer).toBeVisible();
+
+      const leftPane = page.getByRole("region", { name: "Original version" });
+      const rightPane = page.getByRole("region", { name: "Modified version" });
+
+      await expect(leftPane).toBeVisible();
+      await expect(rightPane).toBeVisible();
+
+      // Get bounding boxes to verify horizontal layout
+      const leftBox = await leftPane.boundingBox();
+      const rightBox = await rightPane.boundingBox();
+
+      // Fail fast if bounding boxes are null
+      if (!leftBox || !rightBox) {
+        throw new Error("Failed to get bounding boxes for panes");
+      }
+
+      // Verify panes are side-by-side: same Y position, left pane ends where right begins
+      // Allow small tolerance for borders
+      expect(Math.abs(leftBox.y - rightBox.y)).toBeLessThan(5);
+      expect(rightBox.x).toBeGreaterThan(leftBox.x);
+      expect(rightBox.x).toBeLessThanOrEqual(leftBox.x + leftBox.width + 5);
+
+      // Each pane should have reasonable width (not collapsed)
+      expect(leftBox.width).toBeGreaterThan(100);
+      expect(rightBox.width).toBeGreaterThan(100);
+    } else {
+      test.skip(true, "Layout test runs in mock mode only");
+    }
+  });
+
   test("Side-by-side view accessibility (S-3.2)", async ({ page }) => {
     const config = getTestConfig();
     await page.goto(config.pageUrl);

--- a/src/features/diff/components/SideBySideDiffView.tsx
+++ b/src/features/diff/components/SideBySideDiffView.tsx
@@ -127,7 +127,7 @@ export function SideBySideDiffView({
   return (
     <div
       ref={containerRef}
-      className="flex overflow-hidden h-full"
+      className="side-by-side-container"
       role="region"
       aria-label="Side-by-side diff view"
     >
@@ -135,7 +135,7 @@ export function SideBySideDiffView({
       {contentFilter !== 'right' && (
         <div
           ref={leftPaneRef}
-          className="flex-1 overflow-auto border-r border-gray-300"
+          className="side-by-side-pane side-by-side-pane-left"
           aria-label="Original version"
           role="region"
           tabIndex={0}
@@ -210,7 +210,7 @@ export function SideBySideDiffView({
       {contentFilter !== 'left' && (
         <div
           ref={rightPaneRef}
-          className="flex-1 overflow-auto"
+          className="side-by-side-pane"
           aria-label="Modified version"
           role="region"
           tabIndex={0}

--- a/src/styles/shared/features.css
+++ b/src/styles/shared/features.css
@@ -395,3 +395,50 @@
   border-top: 1px solid var(--combobox-border);
   margin-top: 16px;
 }
+
+/* ============================================
+   SIDE-BY-SIDE DIFF VIEW
+   ============================================ */
+.side-by-side-container {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+  height: 100%;
+  background-color: var(--main-bg);
+}
+
+.side-by-side-pane {
+  flex: 1;
+  overflow: auto;
+  min-width: 0;
+  background-color: var(--main-bg);
+}
+
+.side-by-side-pane-left {
+  border-right: 1px solid var(--combobox-border);
+}
+
+.side-by-side-pane table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+  table-layout: fixed;
+}
+
+/* Constrain gutter and marker widths in side-by-side mode */
+.side-by-side-pane .diff-gutter {
+  width: 48px;
+  min-width: 48px;
+  max-width: 48px;
+}
+
+.side-by-side-pane .diff-marker {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+}
+
+/* Content cell takes remaining space */
+.side-by-side-pane .diff-content {
+  width: auto;
+}


### PR DESCRIPTION
## Summary
- Fixed side-by-side diff view which was rendering panes vertically stacked instead of horizontally
- Root cause: Tailwind-style classes (`flex`, `flex-1`) were used but the codebase uses custom CSS
- Replaced with proper CSS classes (`.side-by-side-container`, `.side-by-side-pane`)
- Added styling for proper column widths and scrollbar blending

## Test plan
- [x] Added E2E test that verifies panes render side-by-side (checks bounding boxes)
- [x] All existing side-by-side tests pass
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)