### PR TITLE
fix: Correct scroll offset when clicking file in tree

### DIFF
--- a/src/styles/shared/features.css
+++ b/src/styles/shared/features.css
@@ -190,12 +190,13 @@
    DIFF HEADER (Sticky)
    ============================================ */
 
-/* Header dimension variables for scroll-margin calculations */
+/* Header dimension variables for scroll-margin calculations (measured via Playwright getBoundingClientRect) */
 .diff-view-container {
   --diff-header-toolbar-height: 33px;
   --diff-header-iterations-height: 0px; /* Only present when iterations exist */
   --diff-header-border: 1px;
-  --diff-line-height: 23px;
+  --diff-line-height: 23px; /* Measured from rendered .diff-line elements */
+  /* Show 3 lines of context above the first change for better orientation (UX decision) */
   --diff-scroll-context-lines: 3;
   --diff-header-total-height: calc(
     var(--diff-header-toolbar-height) +


### PR DESCRIPTION
## Summary
- Fixed auto-scroll positioning when clicking a file in the tree - first changed line was being hidden behind the sticky header
- Added `scroll-margin-top` using CSS variables that dynamically calculate header height
- Uses `:has()` selector to conditionally include iteration tabs height when visible
- Shows 3 context lines above the first change for better orientation

## Test plan
- [x] Manual verification: Click AGENTS.md in PR #98, first change visible with 3 context lines above

🤖 Generated with [Claude Code](https://claude.com/claude-code)