### PR TITLE
fix: Remove unwanted margin between lines in inline diff view

### DIFF
--- a/src/styles/shared/features.css
+++ b/src/styles/shared/features.css
@@ -1,6 +1,28 @@
 /* Feature Component Styles */
 
 /* ============================================
+   DIFF TABLE (Unified/Inline mode)
+   ============================================ */
+.diff-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+/* Constrain gutter and marker widths in unified/inline mode */
+.diff-table .diff-gutter {
+  width: 48px;
+  min-width: 48px;
+  max-width: 48px;
+}
+
+.diff-table .diff-marker {
+  width: 32px;
+  min-width: 32px;
+  max-width: 32px;
+}
+
+/* ============================================
    DIFF LINE STYLES
    ============================================ */
 .diff-line {


### PR DESCRIPTION
## Summary
- Add `.diff-table` styles with `border-collapse: collapse` to eliminate default table cell spacing that caused visible margins between diff lines
- Constrain gutter (48px) and marker (32px) column widths to match side-by-side view behavior

## Test plan
- [ ] Open a PR in inline/unified diff mode
- [ ] Verify no visible gaps between diff lines
- [ ] Verify gutter columns are appropriately sized (not too wide)
- [ ] Compare with side-by-side view to ensure consistent appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)