### PR TITLE
Use VS syntax themes for CodeFlow and Visual Studio color schemes

### DIFF
--- a/src/features/diff/hooks/useSyntaxTheme.test.ts
+++ b/src/features/diff/hooks/useSyntaxTheme.test.ts
@@ -1,25 +1,26 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { renderHook } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { useSyntaxTheme } from './useSyntaxTheme';
 import { useThemeStore } from '@/features/theme';
 
 describe('useSyntaxTheme', () => {
   beforeEach(() => {
-    // Reset theme store to default
-    useThemeStore.setState({ theme: 'dark' });
+    act(() => {
+      useThemeStore.setState({ theme: 'dark', diffColorScheme: 'github' });
+    });
   });
 
   it('returns atom-one-dark style for dark theme', () => {
-    useThemeStore.setState({ theme: 'dark' });
     const { result } = renderHook(() => useSyntaxTheme());
 
-    // atom-one-dark has characteristic colors
     expect(result.current.hljs).toBeDefined();
     expect(result.current.hljs?.background).toBe('transparent');
   });
 
   it('returns github style for light theme', () => {
-    useThemeStore.setState({ theme: 'light' });
+    act(() => {
+      useThemeStore.setState({ theme: 'light' });
+    });
     const { result } = renderHook(() => useSyntaxTheme());
 
     expect(result.current.hljs).toBeDefined();
@@ -27,7 +28,9 @@ describe('useSyntaxTheme', () => {
   });
 
   it('returns atom-one-dark style for black theme', () => {
-    useThemeStore.setState({ theme: 'black' });
+    act(() => {
+      useThemeStore.setState({ theme: 'black' });
+    });
     const { result } = renderHook(() => useSyntaxTheme());
 
     expect(result.current.hljs).toBeDefined();
@@ -35,7 +38,9 @@ describe('useSyntaxTheme', () => {
   });
 
   it('returns a11y-dark style for high-contrast theme', () => {
-    useThemeStore.setState({ theme: 'high-contrast' });
+    act(() => {
+      useThemeStore.setState({ theme: 'high-contrast' });
+    });
     const { result } = renderHook(() => useSyntaxTheme());
 
     expect(result.current.hljs).toBeDefined();
@@ -46,7 +51,9 @@ describe('useSyntaxTheme', () => {
     const themes = ['light', 'dark', 'black', 'high-contrast'] as const;
 
     for (const theme of themes) {
-      useThemeStore.setState({ theme });
+      act(() => {
+        useThemeStore.setState({ theme });
+      });
       const { result } = renderHook(() => useSyntaxTheme());
 
       expect(result.current.hljs?.background).toBe('transparent');
@@ -56,17 +63,20 @@ describe('useSyntaxTheme', () => {
   });
 
   it('updates style when theme changes', () => {
-    useThemeStore.setState({ theme: 'light' });
+    act(() => {
+      useThemeStore.setState({ theme: 'light' });
+    });
     const { result, rerender } = renderHook(() => useSyntaxTheme());
 
     const lightStyle = result.current;
 
-    useThemeStore.setState({ theme: 'dark' });
+    act(() => {
+      useThemeStore.setState({ theme: 'dark' });
+    });
     rerender();
 
     const darkStyle = result.current;
 
-    // Styles should be different objects (different themes have different token colors)
     expect(lightStyle).not.toBe(darkStyle);
   });
 

--- a/src/features/diff/hooks/useSyntaxTheme.ts
+++ b/src/features/diff/hooks/useSyntaxTheme.ts
@@ -1,17 +1,42 @@
 import { useMemo } from 'react';
-import { useThemeStore, type Theme } from '@/features/theme';
+import { useThemeStore, type Theme, type DiffColorScheme } from '@/features/theme';
 import github from 'react-syntax-highlighter/dist/esm/styles/hljs/github';
 import atomOneDark from 'react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark';
 import a11yDark from 'react-syntax-highlighter/dist/esm/styles/hljs/a11y-dark';
+import vs from 'react-syntax-highlighter/dist/esm/styles/hljs/vs';
+import vs2015 from 'react-syntax-highlighter/dist/esm/styles/hljs/vs2015';
 
 type HljsStyle = typeof github;
+type W = '*';
+type ThemePattern = Theme | W;
+type SchemePattern = DiffColorScheme | W;
 
-const THEME_TO_HLJS_STYLE: Record<Theme, HljsStyle> = {
-  light: github,
-  dark: atomOneDark,
-  black: atomOneDark,
-  'high-contrast': a11yDark,
-};
+// Pattern matching: [theme, colorScheme] -> style (first match wins)
+const STYLE_PATTERNS: [ThemePattern, SchemePattern, HljsStyle][] = [
+  // High contrast always uses a11y-dark
+  ['high-contrast', '*', a11yDark],
+  // CodeFlow and Visual Studio schemes use VS syntax themes
+  ['light', 'codeflow-classic', vs],
+  ['light', 'codeflow-redgreen', vs],
+  ['light', 'visual-studio', vs],
+  ['dark', 'codeflow-classic', vs2015],
+  ['dark', 'codeflow-redgreen', vs2015],
+  ['dark', 'visual-studio', vs2015],
+  ['black', 'codeflow-classic', vs2015],
+  ['black', 'codeflow-redgreen', vs2015],
+  ['black', 'visual-studio', vs2015],
+  // Default: GitHub schemes use GitHub/Atom themes
+  ['light', '*', github],
+  ['dark', '*', atomOneDark],
+  ['black', '*', atomOneDark],
+];
+
+function matchStyle(theme: Theme, scheme: DiffColorScheme): HljsStyle {
+  const match = STYLE_PATTERNS.find(
+    ([t, s]) => (t === '*' || t === theme) && (s === '*' || s === scheme)
+  );
+  return match?.[2] ?? github;
+}
 
 /**
  * Returns an hljs syntax highlighting style that matches the current UI theme.
@@ -19,9 +44,10 @@ const THEME_TO_HLJS_STYLE: Record<Theme, HljsStyle> = {
  */
 export function useSyntaxTheme(): HljsStyle {
   const theme = useThemeStore((state) => state.theme);
+  const diffColorScheme = useThemeStore((state) => state.diffColorScheme);
 
   return useMemo(() => {
-    const baseStyle = THEME_TO_HLJS_STYLE[theme];
+    const baseStyle = matchStyle(theme, diffColorScheme);
     return {
       ...baseStyle,
       hljs: {
@@ -31,5 +57,5 @@ export function useSyntaxTheme(): HljsStyle {
         margin: 0,
       },
     };
-  }, [theme]);
+  }, [theme, diffColorScheme]);
 }


### PR DESCRIPTION
## Summary
- CodeFlow (classic/redgreen) and Visual Studio diff color schemes now use VS/VS2015 highlight.js syntax themes
- Other color schemes (GitHub variants) continue using GitHub/Atom themes
- Maintains a11y-dark for high-contrast mode across all schemes

## Test plan
- [ ] Switch to CodeFlow Classic color scheme, verify VS syntax highlighting in light/dark/black modes
- [ ] Switch to Visual Studio color scheme, verify VS syntax highlighting
- [ ] Switch to GitHub color scheme, verify GitHub/Atom syntax highlighting still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/121)**

<!-- codjiflo-link -->