### PR TITLE
Update next-env.d.ts for Turbopack dev mode path

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Updates the auto-generated `next-env.d.ts` to use the correct Turbopack dev mode path (`.next/dev/types/routes.d.ts` instead of `.next/types/routes.d.ts`)

## Test plan
- [ ] Verify `npm run dev` starts without TypeScript errors
- [ ] Verify `npm run build` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/127)**

<!-- codjiflo-link -->