### PR TITLE
Fix 404 for logo image on login page

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -57,7 +57,7 @@ function LoginContent() {
           <div className="login-header">
             <div className="logo">
               <Image
-                src="/icons/codjiflo.svg"
+                src="/codjiflo.svg"
                 alt="CodjiFlo"
                 width={48}
                 height={48}
@@ -140,7 +140,7 @@ function LoadingFallback() {
           <div className="login-header">
             <div className="logo">
               <Image
-                src="/icons/codjiflo.svg"
+                src="/codjiflo.svg"
                 alt="CodjiFlo"
                 width={48}
                 height={48}


### PR DESCRIPTION
## Summary
- Fixed 404 error for CodjiFlo logo on the login page
- The image path was incorrectly set to `/icons/codjiflo.svg` instead of `/codjiflo.svg`

## Test plan
- [ ] Navigate to `/dashboard` (redirects to `/login`)
- [ ] Verify the CodjiFlo logo displays correctly
- [ ] Check browser network tab shows no 404 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/128)**

<!-- codjiflo-link -->