### PR TITLE
Add manual trigger support to CI/CD PR workflow

### DIFF
--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -1,221 +1,90 @@
-name: CI/CD Pull Request
-permissions:
-  contents: read
-  actions: read
-  pull-requests: write
+commit b4e696c96f240c50425a7c8666712ba44d845f53
+Author: Pedro Paulo Vezza Campos <pedro@vezza.com.br>
+Date:   Sat Jan 10 11:44:21 2026 -0800
 
-on:
-  pull_request:
-    branches: [main]
-    types: [opened, synchronize, reopened]
+    feat: Add manual trigger support to CI/CD PR workflow
+    
+    - Accept workflow_dispatch with pr_number input parameter
+    - Support both automatic PR triggers and manual invocation
+    - Use PR_NUMBER env variable for consistent reference across all jobs
+    
+    Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
 
-concurrency:
-  group: pr-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
-jobs:
-  lint:
-    runs-on: ubuntu-slim
-    steps:
-      - name: Checkout repository
-        timeout-minutes: 1
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        timeout-minutes: 1
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
-
-      - name: Run linter
-        timeout-minutes: 1
-        run: npm run lint:check
-
-  typecheck:
-    runs-on: ubuntu-slim
-    steps:
-      - name: Checkout repository
-        timeout-minutes: 1
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        timeout-minutes: 1
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
-
-      - name: Run typecheck
-        timeout-minutes: 1
-        run: npm run typecheck
-
-  unit-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        timeout-minutes: 1
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        timeout-minutes: 1
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
-
-      - name: Run unit tests with coverage
-        timeout-minutes: 2
-        run: npm run test:coverage
-
-      - name: Download base coverage
-        if: always()
-        id: download-coverage-baseline
-        uses: dawidd6/action-download-artifact@v6
-        with:
-          workflow: ci-cd-main.yml
-          branch: main
-          name: coverage-baseline
-          path: coverage-baseline
-        continue-on-error: true
-
-      - name: Coverage report with delta
-        if: always()
-        uses: davelosert/vitest-coverage-report-action@v2
-        with:
-          file-coverage-mode: changes
-          pr-number: ${{ github.event.pull_request.number }}
-          json-summary-compare-path: ${{ steps.download-coverage-baseline.outcome == 'success' && 'coverage-baseline/coverage-summary.json' || '' }}
-          threshold-icons: "{0: '🔴', 70: '🟡', 75: '🔵', 85: '🟢'}"
-
-  e2e-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        timeout-minutes: 1
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        timeout-minutes: 1
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
-
-      - name: Install Playwright browsers
-        timeout-minutes: 1
-        run: npx playwright install --with-deps chromium-headless-shell
-
-      - name: Run E2E tests (mock mode)
-        timeout-minutes: 3
-        run: npm run test:e2e
-
-  storybook-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        timeout-minutes: 1
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        timeout-minutes: 1
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
-
-      - name: Install Playwright browsers
-        timeout-minutes: 1
-        run: npx playwright install --with-deps chromium-headless-shell
-
-      - name: Run storybook tests
-        timeout-minutes: 1
-        run: npm run test:storybook
-
-  manual-tests:
-    runs-on: ubuntu-slim
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        timeout-minutes: 1
-        uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: "npm"
-
-      - run: npm ci
-
-      - name: Deploy to Vercel
-        id: deploy
-        run: |
-          url=$(npx vercel deploy --token=${{ secrets.VERCEL_TOKEN }} --meta gitCommitSha=${{ github.sha }} --meta gitPrNumber=${{ github.event.pull_request.number }})
-          echo "url=$url" >> $GITHUB_OUTPUT
-
-      - name: Set deployment alias
-        run: |
-          npx vercel alias set ${{ steps.deploy.outputs.url }} pr-${{ github.event.pull_request.number }}.codjiflo.vza.net --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
-
-      - name: Find Comment
-        uses: peter-evans/find-comment@v3
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: 'Preview Deployment'
-
-      - name: Comment on PR
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## Preview Deployment
-
-            :rocket: **Preview:** https://pr-${{ github.event.pull_request.number }}.codjiflo.vza.net/${{ github.repository }}/${{ github.event.pull_request.number }}
-
-            _Updated for commit ${{ github.event.pull_request.head.sha }}_
-          edit-mode: replace
-
-  # Capture iteration data for CodjiFlo iteration tracking
-  capture-iteration:
-    runs-on: ubuntu-slim
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Capture PR iteration
-        uses: ./action
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload iteration artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: codjiflo-pr-${{ github.event.pull_request.number }}-run-${{ github.run_id }}
-          path: codjiflo-data/
-          retention-days: 90
-
+diff --git a/.github/workflows/ci-cd-pr.yml b/.github/workflows/ci-cd-pr.yml
+index 3e2712f..2922350 100644
+--- a/.github/workflows/ci-cd-pr.yml
++++ b/.github/workflows/ci-cd-pr.yml
+@@ -8,9 +8,18 @@ on:
+   pull_request:
+     branches: [main]
+     types: [opened, synchronize, reopened]
++  workflow_dispatch:
++    inputs:
++      pr_number:
++        description: 'PR number to run workflow on'
++        required: true
++        type: number
++
++env:
++  PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+ 
+ concurrency:
+-  group: pr-${{ github.event.pull_request.number }}
++  group: pr-${{ github.event.pull_request.number || inputs.pr_number }}
+   cancel-in-progress: true
+ 
+ jobs:
+@@ -96,7 +105,7 @@ jobs:
+         uses: davelosert/vitest-coverage-report-action@v2
+         with:
+           file-coverage-mode: changes
+-          pr-number: ${{ github.event.pull_request.number }}
++          pr-number: ${{ env.PR_NUMBER }}
+           json-summary-compare-path: ${{ steps.download-coverage-baseline.outcome == 'success' && 'coverage-baseline/coverage-summary.json' || '' }}
+           threshold-icons: "{0: '🔴', 70: '🟡', 75: '🔵', 85: '🟢'}"
+ 
+@@ -172,18 +181,18 @@ jobs:
+       - name: Deploy to Vercel
+         id: deploy
+         run: |
+-          url=$(npx vercel deploy --token=${{ secrets.VERCEL_TOKEN }} --meta gitCommitSha=${{ github.sha }} --meta gitPrNumber=${{ github.event.pull_request.number }})
++          url=$(npx vercel deploy --token=${{ secrets.VERCEL_TOKEN }} --meta gitCommitSha=${{ github.sha }} --meta gitPrNumber=${{ env.PR_NUMBER }})
+           echo "url=$url" >> $GITHUB_OUTPUT
+ 
+       - name: Set deployment alias
+         run: |
+-          npx vercel alias set ${{ steps.deploy.outputs.url }} pr-${{ github.event.pull_request.number }}.codjiflo.vza.net --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
++          npx vercel alias set ${{ steps.deploy.outputs.url }} pr-${{ env.PR_NUMBER }}.codjiflo.vza.net --token=${{ secrets.VERCEL_TOKEN }} --scope=${{ secrets.VERCEL_ORG_ID }}
+ 
+       - name: Find Comment
+         uses: peter-evans/find-comment@v3
+         id: fc
+         with:
+-          issue-number: ${{ github.event.pull_request.number }}
++          issue-number: ${{ env.PR_NUMBER }}
+           comment-author: 'github-actions[bot]'
+           body-includes: 'Preview Deployment'
+ 
+@@ -191,11 +200,11 @@ jobs:
+         uses: peter-evans/create-or-update-comment@v4
+         with:
+           comment-id: ${{ steps.fc.outputs.comment-id }}
+-          issue-number: ${{ github.event.pull_request.number }}
++          issue-number: ${{ env.PR_NUMBER }}
+           body: |
+             ## Preview Deployment
+ 
+-            :rocket: **Preview:** https://pr-${{ github.event.pull_request.number }}.codjiflo.vza.net/${{ github.repository }}/${{ github.event.pull_request.number }}
++            :rocket: **Preview:** https://pr-${{ env.PR_NUMBER }}.codjiflo.vza.net/${{ github.repository }}/${{ env.PR_NUMBER }}
+ 
+             _Updated for commit ${{ github.event.pull_request.head.sha }}_
+           edit-mode: replace
+@@ -215,7 +224,7 @@ jobs:
+       - name: Upload iteration artifact
+         uses: actions/upload-artifact@v4
+         with:
+-          name: codjiflo-pr-${{ github.event.pull_request.number }}-run-${{ github.run_id }}
++          name: codjiflo-pr-${{ env.PR_NUMBER }}-run-${{ github.run_id }}
+           path: codjiflo-data/
+           retention-days: 90
+ 


### PR DESCRIPTION
## Summary
- Add workflow_dispatch trigger to CI/CD PR workflow
- Accept pr_number as input parameter
- Support both automatic PR triggers and manual invocation

## Test plan
- Verify workflow can be triggered manually via GitHub Actions UI
- Verify workflow variables work correctly with manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)