### PR TITLE
Fix workflow concurrency syntax error

### DIFF
--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -19,7 +19,7 @@ env:
   PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
 
 concurrency:
-  group: pr-${{ env.PR_NUMBER }}
+  group: pr-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- Fix concurrency group to not use env context
- Use direct expression since env is not available in concurrency key

## Test plan
- Verify workflow syntax is valid
- Verify manual trigger works

🤖 Generated with [Claude Code](https://claude.com/claude-code)