### PR TITLE
fix: preserve syntax highlighting when showing whitespace (Issue #131)

### DIFF
--- a/e2e/diff-views.spec.ts
+++ b/e2e/diff-views.spec.ts
@@ -307,6 +307,52 @@ const baz = 'qux';
     }
   });
 
+  test("Syntax highlighting preserved when showing whitespace (Issue #131)", async ({
+    page,
+  }) => {
+    const config = getTestConfig();
+    await page.goto(config.pageUrl);
+    await page.waitForLoadState("load");
+
+    const fileNav = page.getByRole("navigation", { name: /Changed files/i });
+    await expect(fileNav).toBeVisible();
+
+    if (isMockMode()) {
+      await fileNav.getByText("src/example.ts").click();
+      await expect(
+        page.getByRole("heading", { name: "src/example.ts" })
+      ).toBeVisible();
+
+      const diffRegion = page.getByRole("region", { name: /Diff content/i });
+      await expect(diffRegion).toBeVisible();
+
+      // Before enabling whitespace visibility, verify syntax highlighting is present.
+      // SyntaxHighlighter uses inline styles (useInlineStyles=true), so we check for
+      // spans with color styles, which indicates syntax highlighting is active.
+      // Example: <span style="color: rgb(215, 58, 73)">const</span>
+      const syntaxSpansBefore = await diffRegion.locator('span[style*="color:"]').count();
+      expect(syntaxSpansBefore).toBeGreaterThan(0);
+
+      // Enable whitespace visibility using 'B' key
+      await page.locator("body").click();
+      await page.keyboard.press("b");
+
+      // Verify whitespace indicators are visible (· for spaces)
+      await expect(diffRegion.locator('.whitespace-visible').first()).toBeVisible();
+
+      // After enabling whitespace visibility, syntax highlighting should still be present
+      const syntaxSpansAfter = await diffRegion.locator('span[style*="color:"]').count();
+      expect(syntaxSpansAfter).toBeGreaterThan(0);
+
+      // The count should be similar (whitespace toggle shouldn't remove syntax spans)
+      // Allow some variance but ensure highlighting is preserved
+      expect(syntaxSpansAfter).toBeGreaterThanOrEqual(syntaxSpansBefore * 0.8);
+    } else {
+      // Prod mode: skip this test
+      test.skip(true, "Syntax highlighting test runs in mock mode only");
+    }
+  });
+
   test("Full file toggle switches between changes only and full file (S-3.1)", async ({
     page,
   }) => {

--- a/src/features/diff/components/DiffLine.test.tsx
+++ b/src/features/diff/components/DiffLine.test.tsx
@@ -6,8 +6,53 @@ import type { ParsedDiffLine } from '../types';
 // Mock react-syntax-highlighter - factory must use inline function
 vi.mock('react-syntax-highlighter', async () => {
   const React = await import('react');
-  const MockComponent = ({ children }: { children: string }) =>
-    React.createElement('span', { 'data-testid': 'syntax-highlighter' }, children);
+
+  interface MockRendererNode {
+    type: 'element' | 'text';
+    value?: string | number;
+    tagName?: string;
+    properties?: { className?: string[]; style?: React.CSSProperties };
+    children?: MockRendererNode[];
+  }
+
+  interface MockRendererProps {
+    rows: MockRendererNode[];
+    stylesheet: Record<string, React.CSSProperties>;
+    useInlineStyles: boolean;
+  }
+
+  type MockRenderer = (props: MockRendererProps) => React.ReactNode;
+
+  // Build a simple AST from the content (simulates what hljs would produce)
+  function buildMockAst(content: string): MockRendererNode[] {
+    return [{
+      type: 'element',
+      tagName: 'span',
+      properties: { className: [] },
+      children: [{ type: 'text', value: content }],
+    }];
+  }
+
+  interface MockProps {
+    children: string;
+    renderer?: MockRenderer;
+    style?: Record<string, React.CSSProperties>;
+    useInlineStyles?: boolean;
+  }
+
+  const MockComponent = ({ children, renderer, style = {}, useInlineStyles = true }: MockProps) => {
+    // If a custom renderer is provided, use it (this is key for the whitespace fix!)
+    if (renderer) {
+      const rows = buildMockAst(children);
+      return React.createElement(
+        'span',
+        { 'data-testid': 'syntax-highlighter' },
+        renderer({ rows, stylesheet: style, useInlineStyles })
+      );
+    }
+    // Fallback: just render children
+    return React.createElement('span', { 'data-testid': 'syntax-highlighter' }, children);
+  };
   MockComponent.registerLanguage = vi.fn();
   return { Light: MockComponent };
 });

--- a/src/features/diff/components/DiffLine.tsx
+++ b/src/features/diff/components/DiffLine.tsx
@@ -1,3 +1,4 @@
+import { createElement } from 'react';
 import { Light as SyntaxHighlighter } from 'react-syntax-highlighter';
 import typescript from 'react-syntax-highlighter/dist/esm/languages/hljs/typescript';
 import javascript from 'react-syntax-highlighter/dist/esm/languages/hljs/javascript';
@@ -10,6 +11,24 @@ import markdown from 'react-syntax-highlighter/dist/esm/languages/hljs/markdown'
 import type { ParsedDiffLine, WordDiffSegment } from '../types';
 import { Button } from '@/components';
 import { useSyntaxTheme } from '../hooks/useSyntaxTheme';
+
+// Type for syntax highlighter renderer node (from @types/react-syntax-highlighter)
+interface RendererNode {
+  type: 'element' | 'text';
+  value?: string | number;
+  tagName?: keyof React.JSX.IntrinsicElements | React.ComponentType<unknown>;
+  properties?: { className?: string[]; style?: React.CSSProperties; [key: string]: unknown };
+  children?: RendererNode[];
+}
+
+interface RendererProps {
+  rows: RendererNode[];
+  stylesheet: Record<string, React.CSSProperties>;
+  useInlineStyles: boolean;
+}
+
+// Custom renderer type to match react-syntax-highlighter's expectations
+type CustomRenderer = (props: RendererProps) => React.ReactNode;
 
 // Register languages for syntax highlighting
 SyntaxHighlighter.registerLanguage('typescript', typescript);
@@ -119,6 +138,155 @@ const codeStyle: React.CSSProperties = {
   whiteSpace: 'pre',
   overflow: 'visible',
 };
+
+/**
+ * Create a React element from a renderer node, preserving inline styles.
+ * This is the core rendering function used by createWhitespaceRenderer.
+ */
+function createElementFromNode(
+  node: RendererNode,
+  stylesheet: Record<string, React.CSSProperties>,
+  useInlineStyles: boolean,
+  key: string | number
+): React.ReactNode {
+  if (node.type === 'text') {
+    return node.value;
+  }
+
+  const { tagName, properties, children } = node;
+  if (!tagName) return null;
+
+  // Build style from classNames if using inline styles (for syntax highlighting)
+  let style = properties?.style ?? {};
+  const classNames = properties?.className ?? [];
+
+  // Check if this is a custom whitespace-visible element (not from syntax highlighter)
+  const isWhitespaceElement = classNames.includes('whitespace-visible');
+
+  if (useInlineStyles && classNames.length > 0 && !isWhitespaceElement) {
+    // Only apply stylesheet mapping for syntax highlighter classes, not our custom classes
+    const classStyles = classNames
+      .map((className: string) => stylesheet[className])
+      .filter((s): s is React.CSSProperties => Boolean(s));
+    style = classStyles.reduce<React.CSSProperties>(
+      (acc, classStyle) => ({ ...acc, ...classStyle }),
+      { ...style }
+    );
+  }
+
+  const elementProps: Record<string, unknown> = {
+    key,
+    style: useInlineStyles && !isWhitespaceElement ? style : undefined,
+    // Always include className for whitespace elements; otherwise only when not using inline styles
+    className: isWhitespaceElement || !useInlineStyles ? classNames.join(' ') || undefined : undefined,
+  };
+
+  const childElements = children?.map((child, i) =>
+    createElementFromNode(child, stylesheet, useInlineStyles, `${String(key)}-${String(i)}`)
+  );
+
+  return createElement(tagName as string, elementProps, childElements);
+}
+
+/**
+ * Transform a text node to include visible whitespace markers.
+ * Returns an array of nodes: text nodes for regular content, element nodes for whitespace.
+ */
+function transformTextNodeForWhitespace(text: string): RendererNode[] {
+  const result: RendererNode[] = [];
+  let i = 0;
+  let nonWsStart = 0;
+
+  while (i < text.length) {
+    const char = text[i];
+
+    if (char === ' ' || char === '\t') {
+      // Push any accumulated non-whitespace text
+      if (i > nonWsStart) {
+        result.push({
+          type: 'text',
+          value: text.slice(nonWsStart, i),
+        });
+      }
+
+      // Add visible whitespace element
+      result.push({
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['whitespace-visible'] },
+        children: [
+          {
+            type: 'text',
+            value: char === ' ' ? '·' : '→   ',
+          },
+        ],
+      });
+
+      nonWsStart = i + 1;
+    }
+    i++;
+  }
+
+  // Push remaining non-whitespace text
+  if (nonWsStart < text.length) {
+    result.push({
+      type: 'text',
+      value: text.slice(nonWsStart),
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Recursively transform a node tree to include visible whitespace.
+ * Text nodes are transformed; element nodes recurse into children.
+ */
+function transformNodeForWhitespace(node: RendererNode): RendererNode[] {
+  if (node.type === 'text') {
+    const text = String(node.value ?? '');
+    return transformTextNodeForWhitespace(text);
+  }
+
+  // Element node: recursively transform children
+  if (node.children && node.children.length > 0) {
+    const transformedChildren: RendererNode[] = [];
+    for (const child of node.children) {
+      transformedChildren.push(...transformNodeForWhitespace(child));
+    }
+    return [{
+      ...node,
+      children: transformedChildren,
+    }];
+  }
+
+  return [node];
+}
+
+/**
+ * Create a custom renderer that shows visible whitespace while preserving syntax highlighting.
+ * This is used with react-syntax-highlighter's renderer prop.
+ */
+function createWhitespaceRenderer(showWhitespace: boolean): CustomRenderer {
+  return ({ rows, stylesheet, useInlineStyles }: RendererProps) => {
+    return rows.map((row, rowIndex) => {
+      // If whitespace visibility is off, use standard rendering
+      let transformedRow = row;
+      if (showWhitespace) {
+        // Transform the row to include visible whitespace
+        const transformed = transformNodeForWhitespace(row);
+        transformedRow = transformed[0] ?? row;
+      }
+
+      return createElementFromNode(
+        transformedRow,
+        stylesheet,
+        useInlineStyles,
+        `code-segment-${String(rowIndex)}`
+      );
+    });
+  };
+}
 
 /**
  * Render content with word-level diff highlighting (S-3.4)
@@ -233,10 +401,6 @@ export function DiffLine({
           <pre className="diff-code">{line.content}</pre>
         ) : hasWordDiff && line.wordDiff ? (
           <WordDiffContent segments={line.wordDiff} showWhitespace={showWhitespace} />
-        ) : showWhitespace ? (
-          <span className="diff-code">
-            {renderVisibleWhitespace(line.content)}
-          </span>
         ) : (
           <SyntaxHighlighter
             language={language}
@@ -245,6 +409,7 @@ export function DiffLine({
             customStyle={codeStyle}
             PreTag="span"
             CodeTag="span"
+            renderer={createWhitespaceRenderer(showWhitespace) as never}
           >
             {line.content}
           </SyntaxHighlighter>


### PR DESCRIPTION
## Summary

- Fixes issue where syntax highlighting was lost when "Show Whitespace" feature was enabled (pressing 'B')
- Root cause: code had mutually exclusive branches - either syntax highlighting OR visible whitespace, but not both
- Solution: custom renderer for react-syntax-highlighter that transforms AST to include whitespace markers while preserving syntax highlighting

## Changes

1. **DiffLine.tsx**: Added custom renderer that walks through the syntax-highlighted AST and transforms text nodes to include visible whitespace markers (`·` for spaces, `→` for tabs) while preserving the syntax highlighting spans
2. **DiffLine.test.tsx**: Updated mock for `react-syntax-highlighter` to support the custom renderer prop
3. **diff-views.spec.ts**: Added E2E test verifying syntax highlighting is preserved when whitespace visibility is enabled

## Test plan

- [x] E2E test verifies syntax spans exist before AND after enabling whitespace
- [x] Unit tests for whitespace rendering pass
- [x] All existing tests pass (`npm run test:all`)
- [x] Test failure validation: reverted fix to confirm test fails without fix, then restored fix to confirm test passes

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/191)**

<!-- codjiflo-link -->