### PR TITLE
feat: add Vercel Speed Insights for Core Web Vitals tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@vercel/speed-insights": "^1.3.1",
         "diff-match-patch": "^1.0.5",
         "jszip": "^3.10.1",
         "lucide-react": "^0.562.0",
@@ -5096,6 +5097,40 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-1.3.1.tgz",
+      "integrity": "sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vercel/static-build": {
       "version": "2.8.15",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:all": "npm run lint -s && npm run typecheck -s && npm run test -s -- --coverage && npm run test:e2e -s && npm run test:storybook -s"
   },
   "dependencies": {
+    "@vercel/speed-insights": "^1.3.1",
     "diff-match-patch": "^1.0.5",
     "jszip": "^3.10.1",
     "lucide-react": "^0.562.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import './globals.css';
 import { ThemeProvider } from '@/features/theme';
 import { AuthProvider } from '@/features/auth';
@@ -29,6 +30,7 @@ export default function RootLayout({
             {children}
           </AuthProvider>
         </ThemeProvider>
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Adds `@vercel/speed-insights` package for performance monitoring
- Tracks Core Web Vitals (LCP, INP, CLS, TTFB, FCP) automatically
- Data collected on Vercel deployments only (not in dev mode)

## Test plan
- [x] Verified console shows `[Vercel Speed Insights] [vitals]` logs in dev mode
- [ ] Deploy to Vercel preview and verify metrics appear in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/205)**

<!-- codjiflo-link -->