### PR TITLE
Add tmpclaude-* to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,6 @@ storybook-static/
 .env*.local
 # SQL.js WASM files (copied from node_modules at build time)
 public/sql-wasm/
+
+# Claude Code temporary files
+tmpclaude-*


### PR DESCRIPTION
## Summary
- Adds `tmpclaude-*` pattern to `.gitignore` to ignore Claude Code temporary working directories

## Test plan
- [x] Verify `tmpclaude-*` directories are no longer shown as untracked in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/206)**

<!-- codjiflo-link -->