### PR TITLE
test: fail tests on console.error and console.warn

### DIFF
--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,5 +1,26 @@
 import "@testing-library/jest-dom/vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 
+// Fail tests on any console.error or console.warn
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+
+beforeEach(() => {
+    console.error = vi.fn((...args: unknown[]) => {
+        originalConsoleError.apply(console, args);
+        throw new Error(`Unexpected console.error:\n${args.join(" ")}`);
+    });
+
+    console.warn = vi.fn((...args: unknown[]) => {
+        originalConsoleWarn.apply(console, args);
+        throw new Error(`Unexpected console.warn:\n${args.join(" ")}`);
+    });
+});
+
+afterEach(() => {
+    console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
+});
 
 // Mock ResizeObserver (not available in jsdom)
 class ResizeObserverMock {


### PR DESCRIPTION
## Summary
- Makes test suite stricter by failing any test that produces `console.error` or `console.warn` output
- Catches React act() warnings and other issues that would otherwise go unnoticed in stderr

## Usage
Tests that intentionally trigger warnings can mock console methods:
```typescript
vi.spyOn(console, "error").mockImplementation(() => {})
```

## Test plan
- [x] All 973 existing tests pass with the new strict mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/225)**

<!-- codjiflo-link -->