### PR TITLE
fix: kill zombie Next.js processes before starting dev server

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "postinstall": "node scripts/copy-sql-wasm.js",
-    "dev": "node scripts/ensure-env.js && next dev --turbopack",
+    "dev": "node scripts/kill-zombie-next.js && node scripts/ensure-env.js && next dev --turbopack",
     "build": "next build",
     "start": "next start",
     "lint": "eslint . --fix --quiet",

--- a/scripts/kill-zombie-next.js
+++ b/scripts/kill-zombie-next.js
@@ -1,0 +1,62 @@
+import { execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+
+const LOCK_FILE = join(process.cwd(), ".next", "dev", "lock");
+const PROJECT_PATH = process.cwd().replace(/\//g, "\\"); // Normalize to Windows paths
+
+/**
+ * Kills zombie Next.js dev server for THIS project only.
+ * Detects the lock file and finds node processes with this project's path.
+ */
+function killZombieNextProcess() {
+  if (!existsSync(LOCK_FILE)) {
+    return; // No lock file = no dev server was running
+  }
+
+  // Find node processes that contain this project's path in their command line
+  const psCommand = `Get-CimInstance Win32_Process | Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -match '${PROJECT_PATH.replace(/\\/g, "\\\\")}' } | Select-Object -ExpandProperty ProcessId`;
+
+  let pids = [];
+  try {
+    const output = execSync(`pwsh.exe -NoProfile -Command "${psCommand}"`, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    pids = output
+      .trim()
+      .split(/\r?\n/)
+      .filter((pid) => /^\d+$/.test(pid.trim()))
+      .map((pid) => pid.trim());
+  } catch {
+    // No matching processes found
+    return;
+  }
+
+  if (pids.length === 0) {
+    return;
+  }
+
+  console.log(
+    `Found zombie Next.js process(es) for this project: PIDs ${pids.join(", ")}`
+  );
+
+  for (const pid of pids) {
+    try {
+      execSync(`taskkill /PID ${pid} /T /F`, {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch {
+      // Process may have already exited (e.g., killed as child of another)
+    }
+  }
+
+  console.log(`Killed ${pids.length} zombie process(es)`);
+
+  // Small delay to ensure port is released
+  execSync("pwsh.exe -NoProfile -Command Start-Sleep -Milliseconds 500", {
+    stdio: "ignore",
+  });
+}
+
+killZombieNextProcess();


### PR DESCRIPTION
## Summary
- Add `scripts/kill-zombie-next.js` that detects and kills zombie Next.js processes specific to this project
- Uses `.next/dev/lock` file to detect previous dev server and PowerShell to find processes matching this project's path
- Leaves other Next.js servers (different projects) untouched

## Test plan
- [ ] Run `npm run dev`, kill it with Ctrl+C, run again - should start cleanly
- [ ] Run `npm run dev`, kill terminal abruptly, run again - should detect and kill zombie, then start
- [ ] Verify other Next.js dev servers on different projects are not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/235)**

<!-- codjiflo-link -->