### PR TITLE
ci(mirror): remove cancel-in-progress to allow queueing

### DIFF
--- a/.github/workflows/mirror-to-azdo.yml
+++ b/.github/workflows/mirror-to-azdo.yml
@@ -17,7 +17,6 @@ on:
 
 concurrency:
   group: azdo-mirror
-  cancel-in-progress: true
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary
Allow multiple mirror runs to queue sequentially instead of cancelling in-progress runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/247)**

<!-- codjiflo-link -->