### PR TITLE
Fix: Update E2E iteration tests to use valid PR with fresh artifacts

### DIFF
--- a/e2e/prod/iteration-mode/iteration-file-status.spec.ts
+++ b/e2e/prod/iteration-mode/iteration-file-status.spec.ts
@@ -3,10 +3,10 @@ import { setupAuthState } from "../../fixtures/github-mocks";
 
 test.describe("Iteration File Status", () => {
   // Test for bug fix: files first modified in later iterations should show as "modified" not "added"
-  // Uses real PR #97 which has action/action.yml first modified in iteration 2
+  // Uses real PR #11 in codjiflo-e2e-test-repo which has target-file.yml first modified in iteration 2
 
-  // Prod mode configuration - uses real PR #97
-  const config = { owner: "pedropaulovc", repo: "codjiflo", prNumber: 97 };
+  // Prod mode configuration - uses real PR #11 in e2e test repo
+  const config = { owner: "pedropaulovc", repo: "codjiflo-e2e-test-repo", prNumber: 11 };
 
   test.beforeEach(async ({ page }) => {
     await setupAuthState(page);
@@ -16,9 +16,9 @@ test.describe("Iteration File Status", () => {
     page,
   }) => {
     // This test verifies the "base equivalence" fix:
-    // - action/action.yml existed in the PR base but wasn't changed in iteration 1
-    // - action/action.yml was first modified in iteration 2
-    // - When viewing iteration 1, action/action.yml should NOT appear
+    // - target-file.yml existed in the PR base but wasn't changed in iteration 1
+    // - target-file.yml was first modified in iteration 2
+    // - When viewing iteration 1, target-file.yml should NOT appear
     // - When viewing iteration 2, it should show as "M" (modified), not "A" (added)
 
     const pageUrl = `/${config.owner}/${config.repo}/${String(config.prNumber)}`;
@@ -32,32 +32,32 @@ test.describe("Iteration File Status", () => {
     const fileList = page.getByRole("navigation", { name: /Changed files/i });
     await expect(fileList).toBeVisible();
 
-    const actionYmlItem = fileList.locator(".tree-item.file").filter({
-      hasText: /action\.yml/,
+    const targetFileItem = fileList.locator(".tree-item.file").filter({
+      hasText: /target-file\.yml/,
     });
 
-    // --- Iteration 1: action/action.yml should NOT appear ---
+    // --- Iteration 1: target-file.yml should NOT appear ---
     const iteration1Tab = page.getByTestId("iteration-tab-1");
     await iteration1Tab.click();
     await expect(iteration1Tab).toHaveClass(/selected/);
 
-    // action/action.yml should not be visible (wasn't modified in iteration 1)
-    await expect(actionYmlItem).toBeHidden();
+    // target-file.yml should not be visible (wasn't modified in iteration 1)
+    await expect(targetFileItem).toBeHidden();
 
-    // --- Iteration 2: action/action.yml should appear as "M" (modified) ---
+    // --- Iteration 2: target-file.yml should appear as "M" (modified) ---
     const iteration2Tab = page.getByTestId("iteration-tab-2");
     await iteration2Tab.click();
     await expect(iteration2Tab).toHaveClass(/selected/);
 
-    // action/action.yml should now be visible
-    await expect(actionYmlItem).toBeVisible();
+    // target-file.yml should now be visible
+    await expect(targetFileItem).toBeVisible();
 
     // Check the change-type indicator shows "M" (modified), not "A" (added)
-    const changeTypeIndicator = actionYmlItem.locator(".change-type");
+    const changeTypeIndicator = targetFileItem.locator(".change-type");
     await expect(changeTypeIndicator).toHaveText("M");
 
     // Also verify via aria-label that it says "modified" not "added"
-    const ariaLabel = await actionYmlItem.getAttribute("aria-label");
+    const ariaLabel = await targetFileItem.getAttribute("aria-label");
     expect(ariaLabel).toContain("modified");
     expect(ariaLabel).not.toContain("added");
   });
@@ -94,15 +94,15 @@ test.describe("Iteration File Status", () => {
     await expect(tab1).toHaveClass(/selected/);
     await expect(tab2).toHaveClass(/selected/);
 
-    // action/action.yml should appear as "M" (modified), not "A" (added)
+    // target-file.yml should appear as "M" (modified), not "A" (added)
     const fileList = page.getByRole("navigation", { name: /Changed files/i });
-    const actionYmlItem = fileList.locator(".tree-item.file").filter({
-      hasText: /action\.yml/,
+    const targetFileItem = fileList.locator(".tree-item.file").filter({
+      hasText: /target-file\.yml/,
     });
 
-    await expect(actionYmlItem).toBeVisible();
+    await expect(targetFileItem).toBeVisible();
 
-    const changeTypeIndicator = actionYmlItem.locator(".change-type");
+    const changeTypeIndicator = targetFileItem.locator(".change-type");
     await expect(changeTypeIndicator).toHaveText("M");
   });
 });

--- a/e2e/prod/iteration-mode/iteration-tabs-ui.spec.ts
+++ b/e2e/prod/iteration-mode/iteration-tabs-ui.spec.ts
@@ -2,11 +2,11 @@ import { test, expect } from "@playwright/test";
 import { setupAuthState } from "../../fixtures/github-mocks";
 
 test.describe("Iteration Tabs UI (Prod Mode)", () => {
-  // These tests require real iteration artifacts from PR #75
+  // These tests require real iteration artifacts from PR #11 in e2e test repo
   const iterationTestPR = {
     owner: "pedropaulovc",
-    repo: "codjiflo",
-    prNumber: 75,
+    repo: "codjiflo-e2e-test-repo",
+    prNumber: 11,
   };
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Problem

The E2E iteration tests in prod mode were failing because they referenced PR #97, which has an expired artifact (90-day GitHub artifact retention).

## Solution

Created a dedicated test infrastructure with fresh, valid iteration data:

### New Test Infrastructure
1. **Action Repository**: [](https://github.com/pedropaulovc/codjiflo-action)
   - Standalone repository for the CodjiFlo GitHub Action
   - Enables reuse across test repositories

2. **E2E Test Repository**: [](https://github.com/pedropaulovc/codjiflo-e2e-test-repo)
   - Dedicated repository for E2E test scenarios
   - Includes workflow using the CodjiFlo action
   - Test data in `file-first-modified-later-iteration/` directory

3. **Test PR**: [pedropaulovc/codjiflo-e2e-test-repo#11](https://github.com/pedropaulovc/codjiflo-e2e-test-repo/pull/11)
   - **Iteration 1**: Modified `other-file.js` only
   - **Iteration 2**: Modified `target-file.yml` (exists in base, first change in PR)
   - Tests the "base equivalence" fix (files should show as Modified, not Added)
   - Artifact ID: 5165541620 (2 iterations captured)

### Changes
- Updated `e2e/prod/iteration-mode/iteration-file-status.spec.ts`
  - Changed from PR #97 to PR #11
  - Updated file references from `action/action.yml` to `target-file.yml`
- Updated `e2e/prod/iteration-mode/iteration-tabs-ui.spec.ts`
  - Changed from PR #75 to PR #11

## Test Results

✅ **All 34 E2E prod tests passing consistently**
- Run 1: 34 passed (15.8s)
- Run 2: 34 passed (16.8s)  
- Run 3: 34 passed (17.3s)

## Documentation

Test scenario documentation: [file-first-modified-later-iteration/README.md](https://github.com/pedropaulovc/codjiflo-e2e-test-repo/blob/main/file-first-modified-later-iteration/README.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/249)**

<!-- codjiflo-link -->