### PR TITLE
test: add regression tests for keyboard navigation order (Issue #261)

### DIFF
--- a/e2e/mock/degraded-mode/file-list-sorting.spec.ts
+++ b/e2e/mock/degraded-mode/file-list-sorting.spec.ts
@@ -117,4 +117,72 @@ test.describe("File List Sorting", () => {
     expect(packageBox?.y).toBeLessThan(readmeBox?.y ?? Infinity);
     expect(alphaBox?.y).toBeLessThan(zebraBox?.y ?? Infinity);
   });
+
+  test("keyboard navigation follows alphabetical display order (Issue #261)", async ({
+    page,
+  }) => {
+    // This test verifies that pressing 's' (next file) navigates through files
+    // in the same alphabetical order as displayed in the file list.
+    //
+    // Mock files are in unsorted order: zebra, alpha, README, package.json
+    // Expected display/navigation order: package.json, README.md, src/alpha.ts, src/zebra.ts
+    await page.goto(config.pageUrl);
+
+    // Wait for file list to load
+    const fileNav = page.getByRole("navigation", { name: /Changed files/i });
+    await expect(fileNav).toBeVisible();
+
+    // Start from PR description (default selection)
+    const prDescription = fileNav.getByRole("treeitem", {
+      name: /Pull Request Description/i,
+    });
+    await expect(prDescription).toHaveAttribute("aria-current", "location");
+
+    // Press 's' to go to first file (should be package.json - first alphabetically in root)
+    await page.keyboard.press("s");
+    await expect(
+      fileNav.getByRole("treeitem", { name: /package\.json/ })
+    ).toHaveClass(/selected/);
+
+    // Press 's' to go to next file (should be README.md - second in root)
+    await page.keyboard.press("s");
+    await expect(
+      fileNav.getByRole("treeitem", { name: /README\.md/ })
+    ).toHaveClass(/selected/);
+
+    // Press 's' to go to next file (should be src/alpha.ts - first in src/ folder)
+    await page.keyboard.press("s");
+    await expect(
+      fileNav.getByRole("treeitem", { name: /alpha\.ts/ })
+    ).toHaveClass(/selected/);
+
+    // Press 's' to go to next file (should be src/zebra.ts - last file)
+    await page.keyboard.press("s");
+    await expect(
+      fileNav.getByRole("treeitem", { name: /zebra\.ts/ })
+    ).toHaveClass(/selected/);
+
+    // Now test backward navigation with 'w'
+    // Press 'w' to go back (should be src/alpha.ts)
+    await page.keyboard.press("w");
+    await expect(
+      fileNav.getByRole("treeitem", { name: /alpha\.ts/ })
+    ).toHaveClass(/selected/);
+
+    // Press 'w' again (should be README.md)
+    await page.keyboard.press("w");
+    await expect(
+      fileNav.getByRole("treeitem", { name: /README\.md/ })
+    ).toHaveClass(/selected/);
+
+    // Press 'w' again (should be package.json)
+    await page.keyboard.press("w");
+    await expect(
+      fileNav.getByRole("treeitem", { name: /package\.json/ })
+    ).toHaveClass(/selected/);
+
+    // Press 'w' again (should go back to PR description)
+    await page.keyboard.press("w");
+    await expect(prDescription).toHaveAttribute("aria-current", "location");
+  });
 });

--- a/src/features/keyboard/hooks/useKeyboardShortcuts.test.ts
+++ b/src/features/keyboard/hooks/useKeyboardShortcuts.test.ts
@@ -113,6 +113,82 @@ describe('useKeyboardShortcuts', () => {
   });
 
   describe('iteration-aware file navigation (Issue #189)', () => {
+    it('navigates through files in sorted order regardless of originalIndex order (Issue #261)', () => {
+      // This test verifies the fix for Issue #261: files sorted alphabetically
+      // should be navigated in alphabetical order, not originalIndex order.
+      //
+      // Setup: Files sorted alphabetically but originalIndex is NOT sequential:
+      // - Position 0: zebra.ts (originalIndex: 0) - 'z' comes LAST alphabetically
+      // - Position 1: alpha.ts (originalIndex: 1) - 'a' comes FIRST alphabetically
+      // - Position 2: middle.ts (originalIndex: 2) - 'm' comes MIDDLE alphabetically
+      //
+      // After alphabetical sorting by useIterationAwareFiles:
+      // - Position 0: alpha.ts (originalIndex: 1)
+      // - Position 1: middle.ts (originalIndex: 2)
+      // - Position 2: zebra.ts (originalIndex: 0)
+      //
+      // When on alpha.ts (originalIndex: 1) and pressing 's':
+      // - Should navigate to middle.ts (originalIndex: 2)
+      // - NOT to middle.ts via sequential originalIndex (which would be originalIndex + 1 = 2)
+      //   (In this case they happen to match, but the test below verifies the pattern)
+      const unsortedFiles: IterationAwareFile[] = [
+        {
+          filename: 'alpha.ts', // First alphabetically
+          status: FileChangeStatus.Modified,
+          additions: 5,
+          deletions: 2,
+          changes: 7,
+          patch: '',
+          originalIndex: 1, // Middle in original API order
+        },
+        {
+          filename: 'middle.ts', // Middle alphabetically
+          status: FileChangeStatus.Modified,
+          additions: 5,
+          deletions: 2,
+          changes: 7,
+          patch: '',
+          originalIndex: 2, // Last in original API order
+        },
+        {
+          filename: 'zebra.ts', // Last alphabetically
+          status: FileChangeStatus.Modified,
+          additions: 5,
+          deletions: 2,
+          changes: 7,
+          patch: '',
+          originalIndex: 0, // FIRST in original API order
+        },
+      ];
+
+      vi.mocked(useIterationAwareFiles).mockReturnValue({
+        files: unsortedFiles,
+        isIterationMode: false,
+        totalFilesInPR: 3,
+      });
+
+      // Start on zebra.ts (originalIndex: 0, which is LAST in sorted order)
+      vi.mocked(useDiffStore).mockImplementation((selector) => {
+        const state = {
+          selectedFileIndex: 0, // zebra.ts by originalIndex
+          selectFile: mockSelectFile,
+          scrollToNextChange: mockScrollToNextChange,
+          scrollToPreviousChange: mockScrollToPreviousChange,
+        };
+        return selector(state as never);
+      });
+
+      renderHook(() => useKeyboardShortcuts());
+
+      // Press 'w' to go to previous file
+      const wEvent = new KeyboardEvent('keydown', { key: 'w' });
+      window.dispatchEvent(wEvent);
+
+      // zebra.ts is at position 2 (last) in sorted array
+      // Previous file should be middle.ts (originalIndex: 2)
+      expect(mockSelectFile).toHaveBeenCalledWith(2);
+    });
+
     it('navigates to next file when s is pressed', () => {
       // Selected on first file (index 0)
       vi.mocked(useDiffStore).mockImplementation((selector) => {


### PR DESCRIPTION
## Summary
- Add unit test verifying keyboard navigation with non-sequential `originalIndex` values
- Add E2E test verifying s/w navigation follows alphabetical file order

## Context
Issue #261 reported keyboard navigation selecting files out of order. Investigation found the implementation is correct:
- Files are sorted alphabetically by `useIterationAwareFiles`
- Navigation uses array position (via `findIndex`), not sequential `originalIndex`
- The issue was closed as working-as-designed

These tests prevent regression if the navigation logic is ever modified.

## Test plan
- [x] Unit test passes
- [x] E2E test passes
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/265)**

<!-- codjiflo-link -->