### PR TITLE
ci: add E2E prod mode tests to PR workflow

### DIFF
--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -135,6 +135,34 @@ jobs:
         timeout-minutes: 3
         run: npm run test:e2e
 
+  e2e-tests-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        timeout-minutes: 1
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        timeout-minutes: 1
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        timeout-minutes: 1
+        run: npm ci
+
+      - name: Install Playwright browsers
+        timeout-minutes: 1
+        run: npx playwright install --with-deps chromium-headless-shell
+
+      - name: Run E2E tests (prod mode)
+        timeout-minutes: 3
+        env:
+          CODJIFLO_E2E_GITHUB_TOKEN: ${{ secrets.CODJIFLO_E2E_GITHUB_TOKEN }}
+        run: npm run test:e2e:prod
+
   storybook-tests:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Adds `e2e-tests-prod` job to `ci-cd-pr.yml` workflow
- Runs E2E tests with real GitHub API calls (`npm run test:e2e:prod`)
- Executes in parallel with other CI jobs for faster feedback

## Test plan
- [ ] Verify CI workflow runs successfully
- [ ] Confirm `e2e-tests-prod` job executes with proper secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/270)**

<!-- codjiflo-link -->