### PR TITLE
fix: improve content filter focus styling and tab order

### DIFF
--- a/src/features/diff/components/DiffToolbar.test.tsx
+++ b/src/features/diff/components/DiffToolbar.test.tsx
@@ -389,5 +389,40 @@ describe('DiffToolbar', () => {
       // Dropdown should close
       expect(viewModeButton).toHaveAttribute('aria-expanded', 'false');
     });
+
+    it('content filter radios are focusable via Tab', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <button data-testid="before-button">Before</button>
+          <DiffToolbar />
+        </>
+      );
+
+      // Focus the button before the toolbar
+      const beforeButton = screen.getByTestId('before-button');
+      beforeButton.focus();
+      expect(beforeButton).toHaveFocus();
+
+      // Tab should move focus to the content filter (checked radio)
+      await user.tab();
+      const checkedRadio = screen.getByRole('radio', { name: 'Show Both' });
+      expect(checkedRadio).toHaveFocus();
+    });
+
+    it('content filter focus moves to next element on Tab', async () => {
+      const user = userEvent.setup();
+      render(<DiffToolbar />);
+
+      // Focus the content filter radio
+      const checkedRadio = screen.getByRole('radio', { name: 'Show Both' });
+      checkedRadio.focus();
+      expect(checkedRadio).toHaveFocus();
+
+      // Tab should move focus to the View mode dropdown
+      await user.tab();
+      const viewModeButton = screen.getByRole('button', { name: 'View mode' });
+      expect(viewModeButton).toHaveFocus();
+    });
   });
 });

--- a/src/features/diff/components/DiffToolbar.tsx
+++ b/src/features/diff/components/DiffToolbar.tsx
@@ -302,6 +302,7 @@ function ContentFilterSlider({ value, onChange }: ContentFilterSliderProps) {
               onChange={() => onChange(position)}
               className="sr-only"
               aria-label={FILTER_LABELS[position]}
+              tabIndex={value === position ? 0 : -1}
             />
             <span
               className="content-filter-thumb"

--- a/src/styles/shared/controls.css
+++ b/src/styles/shared/controls.css
@@ -193,7 +193,8 @@
 }
 
 .toolbar-dropdown-button:focus {
-  border-color: var(--focus-border);
+  outline: 2px solid var(--focus-border);
+  outline-offset: -2px;
 }
 
 .toolbar-dropdown-button[aria-expanded="true"] {

--- a/src/styles/shared/features.css
+++ b/src/styles/shared/features.css
@@ -400,6 +400,8 @@
   margin: 0;
   margin-top: -1px; /* Align with other toolbar buttons */
   min-width: 0;
+  /* Prevent fieldset from showing its own focus ring */
+  outline: none;
 }
 
 .content-filter-track {
@@ -485,9 +487,10 @@
 }
 
 /* Show focus indicator on thumb when radio is focused */
+.content-filter-option input:focus + .content-filter-thumb,
 .content-filter-option input:focus-visible + .content-filter-thumb {
   outline: 2px solid var(--focus-border);
-  outline-offset: 1px;
+  outline-offset: -2px;
 }
 
 /* Position thumbs relative to track (accounting for label offset) */

--- a/src/styles/shell/main-content.css
+++ b/src/styles/shell/main-content.css
@@ -33,7 +33,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 4px 8px;
+  padding: 4px 8px 5px 8px;
   background-color: var(--control-bg);
   border-bottom: 1px solid black;
 }


### PR DESCRIPTION
## Summary
- Fix content filter (left/both/right switch) not having consistent focus styling with other toolbar buttons
- Fix content filter not being included in keyboard tab order
- Add proper spacing between toolbar and diff area

## Changes
- Use `outline: 2px solid` with `outline-offset: -2px` for focus styling (matches toolbar dropdown buttons)
- Add roving tabindex to content filter radios so checked option is in tab sequence
- Remove browser default focus ring from toolbar dropdowns
- Add 1px bottom padding to toolbar

## Test plan
- [x] Unit tests pass (37 tests)
- [x] Tab to content filter - should show blue focus outline
- [x] Focus styling matches other toolbar buttons (Inline, Full File, etc.)
- [x] No layout shift when focusing elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/281)**

<!-- codjiflo-link -->