### PR TITLE
chore: suppress console.log output in unit tests

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/tests/setup.ts"],
+    onConsoleLog: () => false,
     include: ["src/**/*.test.{ts,tsx}", "action/src/**/*.test.ts", "e2e/fixtures/**/*.test.ts", "packages/*/src/**/*.test.ts"],
     exclude: [
       "node_modules/",


### PR DESCRIPTION
## Summary
- Adds `onConsoleLog: () => false` to vitest config to suppress console.log output in test results
- Keeps test output clean and focused on test results rather than application logs

## Test plan
- [x] Verified `npm run test` no longer shows `[CodjiFlo] Loading...` messages
- [x] All 1135 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/282)**

<!-- codjiflo-link -->