### PR TITLE
chore: improve E2E stress test reporting and use free OSS runner

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -84,12 +84,12 @@ jobs:
   # E2E STRESS TESTS
   # ============================================================================
   # Runs e2e and e2e:prod 10 times each on a single machine.
-  # - Parallel: Playwright uses max workers (default: 50% of CPU cores)
+  # - Parallel: Playwright uses max workers (4-vCPU free OSS runner = 2 workers)
   # - Sequential: Playwright uses 1 worker
   # ============================================================================
 
   e2e-stress-parallel:
-    runs-on: ubuntu-latest-16-core
+    runs-on: ubuntu-latest
     needs: [deploy-main]
     env:
       CODJIFLO_E2E_GITHUB_TOKEN: ${{ secrets.CODJIFLO_E2E_GITHUB_TOKEN }}
@@ -117,13 +117,42 @@ jobs:
         timeout-minutes: 30
         run: |
           echo "CPU cores: $(nproc), Playwright workers: $(($(nproc) / 2))"
+          FAILURES_FILE=$(mktemp)
+          TOTAL_FAILURES=0
+
           for i in {1..10}; do
             echo "========================================"
             echo "=== Parallel Run $i/10 (max workers) ==="
             echo "========================================"
-            npm run test:e2e
-            npm run test:e2e:prod
+
+            if ! npm run test:e2e 2>&1 | tee /tmp/test-output.txt; then
+              grep -E '^\s+\d+\)' /tmp/test-output.txt | sed 's/^\s*//' >> "$FAILURES_FILE" || true
+              TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
+            fi
+
+            if ! npm run test:e2e:prod 2>&1 | tee /tmp/test-output.txt; then
+              grep -E '^\s+\d+\)' /tmp/test-output.txt | sed 's/^\s*//' >> "$FAILURES_FILE" || true
+              TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
+            fi
           done
+
+          echo ""
+          echo "========================================"
+          echo "=== STRESS TEST SUMMARY ==="
+          echo "========================================"
+
+          if [ -s "$FAILURES_FILE" ]; then
+            echo "❌ FAILING TESTS (sorted by frequency):"
+            echo ""
+            sort "$FAILURES_FILE" | uniq -c | sort -rn
+            echo ""
+            echo "Total failed runs: $TOTAL_FAILURES out of 20"
+            rm "$FAILURES_FILE"
+            exit 1
+          else
+            echo "✅ All 20 test runs passed!"
+            rm "$FAILURES_FILE"
+          fi
 
   e2e-stress-sequential:
     runs-on: ubuntu-latest
@@ -153,10 +182,39 @@ jobs:
       - name: Run E2E stress tests (1 worker) - 10x
         timeout-minutes: 30
         run: |
+          FAILURES_FILE=$(mktemp)
+          TOTAL_FAILURES=0
+
           for i in {1..10}; do
             echo "========================================"
             echo "=== Sequential Run $i/10 (1 worker) ==="
             echo "========================================"
-            npm run test:e2e -- --workers=1
-            npm run test:e2e:prod -- --workers=1
+
+            if ! npm run test:e2e -- --workers=1 2>&1 | tee /tmp/test-output.txt; then
+              grep -E '^\s+\d+\)' /tmp/test-output.txt | sed 's/^\s*//' >> "$FAILURES_FILE" || true
+              TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
+            fi
+
+            if ! npm run test:e2e:prod -- --workers=1 2>&1 | tee /tmp/test-output.txt; then
+              grep -E '^\s+\d+\)' /tmp/test-output.txt | sed 's/^\s*//' >> "$FAILURES_FILE" || true
+              TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
+            fi
           done
+
+          echo ""
+          echo "========================================"
+          echo "=== STRESS TEST SUMMARY ==="
+          echo "========================================"
+
+          if [ -s "$FAILURES_FILE" ]; then
+            echo "❌ FAILING TESTS (sorted by frequency):"
+            echo ""
+            sort "$FAILURES_FILE" | uniq -c | sort -rn
+            echo ""
+            echo "Total failed runs: $TOTAL_FAILURES out of 20"
+            rm "$FAILURES_FILE"
+            exit 1
+          else
+            echo "✅ All 20 test runs passed!"
+            rm "$FAILURES_FILE"
+          fi


### PR DESCRIPTION
## Summary
- E2E stress tests now run all 10 loops even when tests fail, collecting failures along the way
- At the end, produces aggregate report of failing tests sorted by frequency
- Jobs fail only after completing all runs if any tests failed (allows full flakiness analysis)
- Switched parallel runner from `ubuntu-latest-16-core` to `ubuntu-latest` (free 4-vCPU for OSS projects)

## Test plan
- [ ] Merge to main and verify stress tests run all 10 iterations
- [ ] Intentionally break a test to verify failure aggregation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/283)**

<!-- codjiflo-link -->