### PR TITLE
fix: resolve flaky console warning E2E test (Issue #186)

### DIFF
--- a/e2e/mock/degraded-mode/iteration-degraded-mode.spec.ts
+++ b/e2e/mock/degraded-mode/iteration-degraded-mode.spec.ts
@@ -95,26 +95,19 @@ test.describe("Iteration Management - Degraded Mode", () => {
     // This test validates that when no iteration artifact is available,
     // a console warning is emitted to help with debugging and telemetry.
 
-    // Capture console warnings
-    const warnings: string[] = [];
-    page.on("console", (msg) => {
-      if (msg.type() === "warning") {
-        warnings.push(msg.text());
-      }
+    // Set up promise BEFORE navigation to avoid race condition
+    // waitForEvent creates the listener immediately, ensuring we don't miss the warning
+    const warningPromise = page.waitForEvent("console", {
+      predicate: (msg) =>
+        msg.type() === "warning" &&
+        msg.text().includes("[CodjiFlo] Using GitHub API as fallback"),
     });
 
     await page.goto(config.pageUrl);
-    await page.waitForLoadState("load");
 
-    // Wait for file list to ensure iteration loading has completed
-    const fileList = page.getByRole("navigation", { name: /Changed files/i });
-    await expect(fileList).toBeVisible();
-
-    // Verify the degraded mode warning was emitted
-    const degradedWarning = warnings.find((w) =>
-      w.includes("[CodjiFlo] Using GitHub API as fallback")
-    );
-    expect(degradedWarning).toBeDefined();
+    // Wait for the specific warning to be emitted
+    const warningMsg = await warningPromise;
+    const degradedWarning = warningMsg.text();
 
     // Verify the warning includes the reason
     expect(degradedWarning).toContain("Reason:");


### PR DESCRIPTION
## Summary
- Fixed race condition in console warning E2E test that caused flakiness when running in parallel
- Replaced manual `page.on("console")` accumulator pattern with `page.waitForEvent()` which creates the listener before navigation begins
- The previous pattern could miss warnings emitted before the listener was fully registered

## Test plan
- [x] Verified fix with 500 test runs (50 tests × 10 repetitions) - 0 failures
- [x] Full mock E2E suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/286)**

<!-- codjiflo-link -->