### PR TITLE
docs: add file filter feature to spec

### DIFF
--- a/spec/functional/ui-components.md
+++ b/spec/functional/ui-components.md
@@ -175,6 +175,23 @@ enum AcquisitionState {
 
 ### Filtering
 
+The file explorer header contains an inline filter input for quick file name filtering.
+
+#### Filter UI
+
+| Element | Description |
+|---------|-------------|
+| Search icon | Visual indicator (non-interactive) |
+| Filter input | Text input with placeholder "Filter by file name" |
+| Clear button | X icon button, visible only when filter has text |
+
+#### Filter Behavior
+
+- **Case-insensitive substring match**: Filters files by filename
+- **PR Description**: Shown when filter matches "Pull Request Description" or when empty
+- **Escape key**: Clears filter and blurs input
+- **Real-time**: Filtering updates immediately as user types
+
 ```typescript
 interface FileExplorerFilter {
   // Name filter

--- a/spec/stories/milestone-1-spa-github-data.md
+++ b/spec/stories/milestone-1-spa-github-data.md
@@ -113,9 +113,15 @@ Fetch the list of files from `GET /repos/{owner}/{repo}/pulls/{number}/files`. D
 2.  **Interactivity**:
     - [ ] [AC-1.3.4] Clicking a file navigates to the Diff View for that file (Story 1.4).
     - [ ] [AC-1.3.5] Selected file is visually highlighted.
-3.  **Performance**:
+3.  **Filtering**:
+    - [ ] [AC-1.3.10] Filter input is displayed in the file list header with placeholder "Filter by file name".
+    - [ ] [AC-1.3.11] Typing in the filter input filters files by filename (case-insensitive substring match).
+    - [ ] [AC-1.3.12] PR Description item is shown when filter matches "Pull Request Description" or when no filter is active.
+    - [ ] [AC-1.3.13] Clear button (X) appears when filter has text; clicking it clears the filter.
+    - [ ] [AC-1.3.14] Pressing Escape in the filter input clears the filter and blurs the input.
+4.  **Performance**:
     - [ ] [AC-1.3.6] Handle PRs with 50+ files without UI freezing.
-4.  **Accessibility**:
+5.  **Accessibility**:
     - [ ] [AC-1.3.7] File list is keyboard navigable (Up/Down arrow keys).
     - [ ] [AC-1.3.8] Current selection is indicated via `aria-selected="true"`.
     - [ ] [AC-1.3.9] Screen reader announces filename and change stats (e.g., "utils.ts, modified, 10 additions").


### PR DESCRIPTION
## Summary
- Add acceptance criteria AC-1.3.10 through AC-1.3.14 for file name filter in S-1.3 (View Changed Files List)
- Document filter UI elements and behavior in ui-components.md

## Changes
**spec/stories/milestone-1-spa-github-data.md:**
- New "Filtering" section with 5 acceptance criteria covering the filter input, behavior, clear button, and Escape key

**spec/functional/ui-components.md:**
- Filter UI table (search icon, input, clear button)
- Filter behavior documentation (case-insensitive, PR description matching, real-time updates)

## Test plan
- [x] Spec files are valid markdown
- [ ] Review acceptance criteria match implemented behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/288)**

<!-- codjiflo-link -->