### PR TITLE
chore: remove debug console.log from E2E tests

### DIFF
--- a/e2e/mock/degraded-mode/change-navigation-after-file-switch.spec.ts
+++ b/e2e/mock/degraded-mode/change-navigation-after-file-switch.spec.ts
@@ -183,10 +183,6 @@ test.describe("Change Navigation After File Switch", () => {
     // 2. CodeMirror keymap - triggered when editor has focus
     await page.locator("body").click();
 
-    // Log focused element for debugging
-    const focusedElementBefore = await page.evaluate(() => document.activeElement?.tagName);
-    console.log("Focused element before j:", focusedElementBefore);
-
     // === Step 4: Press j - THIS IS WHERE THE BUG OCCURS ===
     // The bug: after switching files with S, pressing J doesn't scroll to first change
     await page.keyboard.press("j");

--- a/e2e/mock/degraded-mode/minimap-zindex.spec.ts
+++ b/e2e/mock/degraded-mode/minimap-zindex.spec.ts
@@ -196,21 +196,12 @@ test.describe("Minimap Z-Index Bug", () => {
     const listbox = page.getByRole("listbox", { name: "View mode" });
     await expect(listbox).toBeVisible();
 
-    const listboxZIndex = await listbox.evaluate((el) => {
-      return window.getComputedStyle(el).zIndex;
-    });
-
     // The dropdown's effective z-index should be higher than the minimap's
     // Since they're in different stacking contexts, we need to check the parent contexts
     const diffHeader = page.locator(".diff-header");
     const diffHeaderZIndex = await diffHeader.evaluate((el) => {
       return window.getComputedStyle(el).zIndex;
     });
-
-    // Log the z-index values for debugging
-    console.log(`Minimap z-index: ${minimapZIndex}`);
-    console.log(`Diff header z-index: ${diffHeaderZIndex}`);
-    console.log(`Listbox z-index: ${listboxZIndex}`);
 
     // The diff-header should have a higher z-index than the minimap
     // to ensure its dropdown children appear above the minimap


### PR DESCRIPTION
## Summary
- Remove leftover debug `console.log` statements from E2E test files
- Cleans up test output by removing unnecessary logging

## Test plan
- [x] Changes are limited to removing debug statements
- [ ] E2E tests still pass (`npm run test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/289)**

<!-- codjiflo-link -->