### PR TITLE
fix: group Storybook packages in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,35 @@
 
 version: 2
 updates:
-  - package-ecosystem:  "npm"
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # Group packages that must stay in sync to avoid version mismatches
+      storybook:
+        patterns:
+          - "storybook"
+          - "@storybook/*"
+          - "eslint-plugin-storybook"
+      codemirror:
+        patterns:
+          - "codemirror"
+          - "@codemirror/*"
+          - "@uiw/react-codemirror"
+      playwright:
+        patterns:
+          - "playwright"
+          - "@playwright/test"
+          - "eslint-plugin-playwright"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      testing-library:
+        patterns:
+          - "@testing-library/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"


### PR DESCRIPTION
## Summary

Configure Dependabot to group related packages to avoid version mismatches:

| Group | Packages | Reason |
|-------|----------|--------|
| **storybook** | `storybook`, `@storybook/*`, `eslint-plugin-storybook` | Vitest addon compatibility |
| **codemirror** | `codemirror`, `@codemirror/*`, `@uiw/react-codemirror` | Editor packages need compatible versions |
| **playwright** | `playwright`, `@playwright/test`, `eslint-plugin-playwright` | Test framework must stay in sync |
| **vitest** | `vitest`, `@vitest/*` | Test runner and plugins |
| **testing-library** | `@testing-library/*` | RTL packages |
| **react** | `react`, `react-dom` | Must be identical versions |

**Root cause**: PRs #297, #298 failed because Dependabot updated `@storybook/react` independently while `@storybook/addon-vitest` remained at an older version.

## Test plan

- [x] Closed broken PRs #297 and #298
- [ ] Verify Dependabot creates grouped PRs for future updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/301)**

<!-- codjiflo-link -->