### PR TITLE
fix(e2e): stabilize flaky tests using locators and auto-retry

### DIFF
--- a/e2e/mock/degraded-mode/inline-gutter-line-numbers.spec.ts
+++ b/e2e/mock/degraded-mode/inline-gutter-line-numbers.spec.ts
@@ -82,28 +82,12 @@ test.describe("Inline mode gutter line numbers", () => {
     return diffRegion;
   }
 
-  // Helper to count gutter columns in a regular (non-spacer, non-header) line
-  async function getGutterColumnCounts(page: import("@playwright/test").Page) {
-    return page.evaluate(() => {
-      const wrappers = document.querySelectorAll(".cm-diff-gutter-wrapper");
-      if (wrappers.length === 0) return { total: 0, leftCount: 0, rightCount: 0 };
-
-      // Find a regular line wrapper (skip spacers with "9999" and headers)
-      for (const wrapper of wrappers) {
-        // Skip headers (have cm-diff-gutter-header class)
-        if (wrapper.classList.contains("cm-diff-gutter-header")) continue;
-
-        // Skip spacers (contain "9999" text)
-        if ((wrapper.textContent || "").includes("9999")) continue;
-
-        const leftCols = wrapper.querySelectorAll(".cm-diff-gutter-left").length;
-        const rightCols = wrapper.querySelectorAll(".cm-diff-gutter-right").length;
-        if (leftCols > 0 || rightCols > 0) {
-          return { total: wrappers.length, leftCount: leftCols, rightCount: rightCols };
-        }
-      }
-      return { total: wrappers.length, leftCount: 0, rightCount: 0 };
-    });
+  // Helper to get a locator for a regular gutter wrapper (excludes headers and spacers)
+  function getRegularGutterWrapper(page: import("@playwright/test").Page) {
+    return page
+      .locator(".cm-diff-gutter-wrapper:not(.cm-diff-gutter-header)")
+      .filter({ hasNotText: "9999" })
+      .first();
   }
 
   test("gutter shows only right line numbers in inline mode with 'both' filter", async ({
@@ -111,13 +95,13 @@ test.describe("Inline mode gutter line numbers", () => {
   }) => {
     await navigateToFile(page);
 
-    const gutterStats = await getGutterColumnCounts(page);
-    expect(gutterStats.total).toBeGreaterThan(0);
+    const wrapper = getRegularGutterWrapper(page);
+    await expect(wrapper).toBeVisible();
 
     // According to spec: 'both' filter should show only right (new) line numbers
     // So we expect 0 left columns and 1 right column
-    expect(gutterStats.leftCount).toBe(0);
-    expect(gutterStats.rightCount).toBe(1);
+    await expect(wrapper.locator(".cm-diff-gutter-left")).toHaveCount(0);
+    await expect(wrapper.locator(".cm-diff-gutter-right")).toHaveCount(1);
   });
 
   test("gutter shows only left line numbers when filter is 'left'", async ({
@@ -132,12 +116,12 @@ test.describe("Inline mode gutter line numbers", () => {
     // Wait for filter to be applied (check the radio button is selected)
     await expect(page.getByRole("radio", { name: "Left Only" })).toBeChecked();
 
-    const gutterStats = await getGutterColumnCounts(page);
-    expect(gutterStats.total).toBeGreaterThan(0);
+    const wrapper = getRegularGutterWrapper(page);
+    await expect(wrapper).toBeVisible();
 
     // When filter is 'left', should show only left (old) line numbers
-    expect(gutterStats.leftCount).toBe(1);
-    expect(gutterStats.rightCount).toBe(0);
+    await expect(wrapper.locator(".cm-diff-gutter-left")).toHaveCount(1);
+    await expect(wrapper.locator(".cm-diff-gutter-right")).toHaveCount(0);
   });
 
   test("gutter shows only right line numbers when filter is 'right'", async ({
@@ -152,11 +136,11 @@ test.describe("Inline mode gutter line numbers", () => {
     // Wait for filter to be applied
     await expect(page.getByRole("radio", { name: "Right Only" })).toBeChecked();
 
-    const gutterStats = await getGutterColumnCounts(page);
-    expect(gutterStats.total).toBeGreaterThan(0);
+    const wrapper = getRegularGutterWrapper(page);
+    await expect(wrapper).toBeVisible();
 
     // When filter is 'right', should show only right (new) line numbers
-    expect(gutterStats.leftCount).toBe(0);
-    expect(gutterStats.rightCount).toBe(1);
+    await expect(wrapper.locator(".cm-diff-gutter-left")).toHaveCount(0);
+    await expect(wrapper.locator(".cm-diff-gutter-right")).toHaveCount(1);
   });
 });

--- a/e2e/mock/degraded-mode/side-filter.spec.ts
+++ b/e2e/mock/degraded-mode/side-filter.spec.ts
@@ -127,12 +127,11 @@ test.describe("Side filter with view modes", () => {
     return diffRegion;
   }
 
-  // Helper to count visible addition and deletion lines
-  async function countLineTypes(diffRegion: import("@playwright/test").Locator) {
-    const additions = await diffRegion.locator('[data-line-type="addition"]').count();
-    const deletions = await diffRegion.locator('[data-line-type="deletion"]').count();
-    return { additions, deletions };
-  }
+  // Locator helpers for line types
+  const additions = (region: import("@playwright/test").Locator) =>
+    region.locator('[data-line-type="addition"]');
+  const deletions = (region: import("@playwright/test").Locator) =>
+    region.locator('[data-line-type="deletion"]');
 
   // Helper to set content filter via keyboard shortcut
   async function setFilter(page: import("@playwright/test").Page, filter: "left" | "both" | "right") {
@@ -157,10 +156,9 @@ test.describe("Side filter with view modes", () => {
     // Set filter to left (deletions only)
     await setFilter(page, "left");
 
-    // Verify filter is applied
-    const counts = await countLineTypes(diffRegion);
-    expect(counts.deletions).toBeGreaterThan(0);
-    expect(counts.additions).toBe(0);
+    // Verify filter is applied (auto-retries until DOM matches)
+    await expect(deletions(diffRegion)).not.toHaveCount(0);
+    await expect(additions(diffRegion)).toHaveCount(0);
   });
 
   test("both filter shows additions and deletions in changes view", async ({ page }) => {
@@ -169,10 +167,9 @@ test.describe("Side filter with view modes", () => {
     // Default is 'both', but set it explicitly
     await setFilter(page, "both");
 
-    // Verify both types are visible
-    const counts = await countLineTypes(diffRegion);
-    expect(counts.deletions).toBeGreaterThan(0);
-    expect(counts.additions).toBeGreaterThan(0);
+    // Verify both types are visible (auto-retries until DOM matches)
+    await expect(deletions(diffRegion)).not.toHaveCount(0);
+    await expect(additions(diffRegion)).not.toHaveCount(0);
   });
 
   test("right filter shows only additions in changes view", async ({ page }) => {
@@ -181,10 +178,9 @@ test.describe("Side filter with view modes", () => {
     // Set filter to right (additions only)
     await setFilter(page, "right");
 
-    // Verify filter is applied
-    const counts = await countLineTypes(diffRegion);
-    expect(counts.additions).toBeGreaterThan(0);
-    expect(counts.deletions).toBe(0);
+    // Verify filter is applied (auto-retries until DOM matches)
+    await expect(additions(diffRegion)).not.toHaveCount(0);
+    await expect(deletions(diffRegion)).toHaveCount(0);
   });
 
   // ============================================================================
@@ -207,10 +203,9 @@ test.describe("Side filter with view modes", () => {
     // Set filter to left (deletions only)
     await setFilter(page, "left");
 
-    // Verify filter is applied in virtualized full file view
-    const counts = await countLineTypes(diffRegion);
-    expect(counts.deletions).toBeGreaterThan(0);
-    expect(counts.additions).toBe(0);
+    // Verify filter is applied in virtualized full file view (auto-retries)
+    await expect(deletions(diffRegion)).not.toHaveCount(0);
+    await expect(additions(diffRegion)).toHaveCount(0);
   });
 
   test("both filter shows additions and deletions in full file view", async ({ page }) => {
@@ -227,10 +222,9 @@ test.describe("Side filter with view modes", () => {
     // Set filter to both
     await setFilter(page, "both");
 
-    // Verify both types are visible
-    const counts = await countLineTypes(diffRegion);
-    expect(counts.deletions).toBeGreaterThan(0);
-    expect(counts.additions).toBeGreaterThan(0);
+    // Verify both types are visible (auto-retries)
+    await expect(deletions(diffRegion)).not.toHaveCount(0);
+    await expect(additions(diffRegion)).not.toHaveCount(0);
   });
 
   test("right filter shows only additions in full file view", async ({ page }) => {
@@ -247,10 +241,9 @@ test.describe("Side filter with view modes", () => {
     // Set filter to right (additions only)
     await setFilter(page, "right");
 
-    // Verify filter is applied in virtualized full file view
-    const counts = await countLineTypes(diffRegion);
-    expect(counts.additions).toBeGreaterThan(0);
-    expect(counts.deletions).toBe(0);
+    // Verify filter is applied in virtualized full file view (auto-retries)
+    await expect(additions(diffRegion)).not.toHaveCount(0);
+    await expect(deletions(diffRegion)).toHaveCount(0);
   });
 
   // ============================================================================
@@ -277,10 +270,9 @@ test.describe("Side filter with view modes", () => {
     // Set filter to left (deletions only)
     await setFilter(page, "left");
 
-    // Verify filter is applied
-    const counts = await countLineTypes(sideBySideRegion);
-    expect(counts.deletions).toBeGreaterThan(0);
-    expect(counts.additions).toBe(0);
+    // Verify filter is applied (auto-retries)
+    await expect(deletions(sideBySideRegion)).not.toHaveCount(0);
+    await expect(additions(sideBySideRegion)).toHaveCount(0);
   });
 
   test("left filter shows only deletions in side-by-side full file view", async ({ page }) => {
@@ -300,10 +292,9 @@ test.describe("Side filter with view modes", () => {
     // Set filter to left (deletions only)
     await setFilter(page, "left");
 
-    // Verify filter is applied in virtualized side-by-side full file view
-    const counts = await countLineTypes(sideBySideRegion);
-    expect(counts.deletions).toBeGreaterThan(0);
-    expect(counts.additions).toBe(0);
+    // Verify filter is applied in virtualized side-by-side full file view (auto-retries)
+    await expect(deletions(sideBySideRegion)).not.toHaveCount(0);
+    await expect(additions(sideBySideRegion)).toHaveCount(0);
   });
 
   test("right filter shows only additions in side-by-side changes view", async ({ page }) => {
@@ -315,10 +306,9 @@ test.describe("Side filter with view modes", () => {
     // Set filter to right (additions only)
     await setFilter(page, "right");
 
-    // Verify filter is applied
-    const counts = await countLineTypes(sideBySideRegion);
-    expect(counts.additions).toBeGreaterThan(0);
-    expect(counts.deletions).toBe(0);
+    // Verify filter is applied (auto-retries)
+    await expect(additions(sideBySideRegion)).not.toHaveCount(0);
+    await expect(deletions(sideBySideRegion)).toHaveCount(0);
   });
 
   test("right filter shows only additions in side-by-side full file view", async ({ page }) => {
@@ -338,9 +328,8 @@ test.describe("Side filter with view modes", () => {
     // Set filter to right (additions only)
     await setFilter(page, "right");
 
-    // Verify filter is applied in virtualized side-by-side full file view
-    const counts = await countLineTypes(sideBySideRegion);
-    expect(counts.additions).toBeGreaterThan(0);
-    expect(counts.deletions).toBe(0);
+    // Verify filter is applied in virtualized side-by-side full file view (auto-retries)
+    await expect(additions(sideBySideRegion)).not.toHaveCount(0);
+    await expect(deletions(sideBySideRegion)).toHaveCount(0);
   });
 });

--- a/e2e/mock/iteration-mode/diff-horizontal-scroll.spec.ts
+++ b/e2e/mock/iteration-mode/diff-horizontal-scroll.spec.ts
@@ -144,7 +144,13 @@ Iterations: 2`,
       throw new Error("Failed to get toolbar bounding box");
     }
 
-    // Find which element allows horizontal scrolling and scroll it
+    // Wait for CodeMirror to render content wide enough to require horizontal scroll
+    await page.waitForFunction(() => {
+      const cmScroller = document.querySelector(".cm-scroller");
+      return cmScroller && cmScroller.scrollWidth > cmScroller.clientWidth;
+    });
+
+    // Now scroll horizontally
     // This tests the BUG: with wrong implementation, .diff-viewer scrolls
     // horizontally and takes the toolbar with it
     const scrollResult = await page.evaluate(() => {

--- a/e2e/mock/iteration-mode/text-wrap-toggle.spec.ts
+++ b/e2e/mock/iteration-mode/text-wrap-toggle.spec.ts
@@ -204,38 +204,34 @@ Iterations: 2`,
       page.getByRole("heading", { name: "src/long-lines.ts" })
     ).toBeVisible();
 
-    // Helper to get row heights and identify which has the long line
+    // Wait for CodeMirror lines containing our test content to be present
+    const longLineLocator = page.locator(".cm-line", { hasText: "veryLongVariableName" });
+    const shortLineLocator = page.locator(".cm-line", { hasText: "short = 'value'" });
+    await expect(longLineLocator.first()).toBeVisible();
+    await expect(shortLineLocator.first()).toBeVisible();
+
+    // Helper to get heights of specific rows (CodeMirror uses .cm-line for each line)
     const getRowHeights = async () => {
       return page.evaluate(() => {
-        // CodeMirror uses .cm-line for each line
         const rows = document.querySelectorAll(".cm-line");
-        const heights: { content: string; height: number }[] = [];
+        let longLineHeight = 0;
+        let shortLineHeight = 0;
         rows.forEach((row) => {
-          const rect = row.getBoundingClientRect();
-          const content = (row.textContent || "").substring(0, 50);
-          heights.push({ content, height: rect.height });
+          const content = row.textContent || "";
+          const height = row.getBoundingClientRect().height;
+          if (content.includes("veryLongVariableName")) longLineHeight = height;
+          if (content.includes("short = 'value'")) shortLineHeight = height;
         });
-        return heights;
+        return { longLineHeight, shortLineHeight };
       });
     };
 
     // With wrap disabled (default), measure row heights
     const heightsNoWrap = await getRowHeights();
-    const longLineRowNoWrap = heightsNoWrap.find((r) =>
-      r.content.includes("veryLongVariableName")
-    );
-    const shortLineRowNoWrap = heightsNoWrap.find((r) =>
-      r.content.includes("short = 'value'")
-    );
-
-    // Both rows should exist
-    if (!longLineRowNoWrap || !shortLineRowNoWrap) {
-      throw new Error("Expected rows not found in diff");
-    }
 
     // Without wrap, rows should be similar height (within 5px tolerance)
     expect(
-      Math.abs(longLineRowNoWrap.height - shortLineRowNoWrap.height)
+      Math.abs(heightsNoWrap.longLineHeight - heightsNoWrap.shortLineHeight)
     ).toBeLessThan(5);
 
     // Enable wrap with keyboard shortcut
@@ -246,24 +242,14 @@ Iterations: 2`,
       page.getByRole("button", { name: /Text wrap/i }).getByText(/^Wrap$/i)
     ).toBeVisible();
 
-    // Re-measure row heights with wrap enabled
-    const heightsWithWrap = await getRowHeights();
-    const longLineRowWithWrap = heightsWithWrap.find((r) =>
-      r.content.includes("veryLongVariableName")
-    );
-    const shortLineRowWithWrap = heightsWithWrap.find((r) =>
-      r.content.includes("short = 'value'")
-    );
-
-    if (!longLineRowWithWrap || !shortLineRowWithWrap) {
-      throw new Error("Expected rows not found in diff after enabling wrap");
-    }
-
-    // With wrap enabled, the long line row should be significantly taller
-    // (at least 1.5x taller, indicating multiple wrapped lines)
-    expect(longLineRowWithWrap.height).toBeGreaterThan(
-      shortLineRowWithWrap.height * 1.5
-    );
+    // Re-measure row heights with wrap enabled (expect.poll auto-retries until CSS applies)
+    // Long line should be significantly taller (at least 1.5x, indicating wrapped lines)
+    await expect
+      .poll(async () => {
+        const heights = await getRowHeights();
+        return heights.longLineHeight / heights.shortLineHeight;
+      })
+      .toBeGreaterThan(1.5);
 
     // Disable wrap again
     await page.keyboard.press("p");
@@ -274,21 +260,12 @@ Iterations: 2`,
     ).toBeVisible();
 
     // Re-measure - heights should be back to similar
-    const heightsAfterDisable = await getRowHeights();
-    const longLineRowAfter = heightsAfterDisable.find((r) =>
-      r.content.includes("veryLongVariableName")
-    );
-    const shortLineRowAfter = heightsAfterDisable.find((r) =>
-      r.content.includes("short = 'value'")
-    );
-
-    if (!longLineRowAfter || !shortLineRowAfter) {
-      throw new Error("Expected rows not found in diff after disabling wrap");
-    }
-
-    // After disabling, rows should be similar height again
-    expect(
-      Math.abs(longLineRowAfter.height - shortLineRowAfter.height)
-    ).toBeLessThan(5);
+    // Use expect.poll() to auto-retry until CSS is applied
+    await expect
+      .poll(async () => {
+        const heights = await getRowHeights();
+        return Math.abs(heights.longLineHeight - heights.shortLineHeight);
+      })
+      .toBeLessThan(5);
   });
 });


### PR DESCRIPTION
## Summary
- Replace `page.evaluate()` + plain assertions with Playwright locators and auto-retry assertions
- Eliminates race conditions with CodeMirror's async rendering
- 4 test files fixed: inline-gutter-line-numbers, side-filter, text-wrap-toggle, diff-horizontal-scroll

## Test plan
- [x] Run `npm run test:e2e` 10x on fixed test files - 0 failures
- [ ] CI passes on full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/307)**

<!-- codjiflo-link -->