### PR TITLE
ci: add retry logic to npm install calls in workflows

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -27,12 +27,12 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Install action dependencies
-        timeout-minutes: 3
-        run: cd action && npm ci
+        timeout-minutes: 4
+        run: for i in 1 2 3; do (cd action && npm ci) && break || sleep 15; done
 
       - name: Run unit tests with coverage
         timeout-minutes: 2
@@ -59,7 +59,9 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - run: npm ci
+      - name: Install dependencies
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Deploy to Vercel (Production)
         run: npx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }} --meta gitCommitSha=${{ github.sha }}
@@ -106,8 +108,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Install Playwright browsers
         timeout-minutes: 1
@@ -139,8 +141,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Install Playwright browsers
         timeout-minutes: 1

--- a/.github/workflows/ci-cd-pr-clean.yml
+++ b/.github/workflows/ci-cd-pr-clean.yml
@@ -19,7 +19,8 @@ jobs:
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - name: Install Vercel CLI
-        run: npm install -g vercel
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm install -g vercel && break || sleep 15; done
 
       - name: Remove Vercel alias
         run: |

--- a/.github/workflows/ci-cd-pr.yml
+++ b/.github/workflows/ci-cd-pr.yml
@@ -38,8 +38,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Run linter
         timeout-minutes: 2
@@ -60,8 +60,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Run typecheck
         timeout-minutes: 2
@@ -82,8 +82,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Run unit tests with coverage
         timeout-minutes: 2
@@ -124,8 +124,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Install Playwright browsers
         timeout-minutes: 1
@@ -150,8 +150,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Install Playwright browsers
         timeout-minutes: 1
@@ -178,8 +178,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        timeout-minutes: 1
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Install Playwright browsers
         timeout-minutes: 1
@@ -204,7 +204,9 @@ jobs:
           node-version: "24"
           cache: "npm"
 
-      - run: npm ci
+      - name: Install dependencies
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Deploy to Vercel
         id: deploy

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -27,7 +27,8 @@ jobs:
           cache: "npm"
 
       - name: Install JavaScript dependencies
-        run: npm ci
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm ci && break || sleep 15; done
 
       - name: Install Playwright browsers
         timeout-minutes: 1

--- a/.github/workflows/janitor.yml
+++ b/.github/workflows/janitor.yml
@@ -125,7 +125,9 @@ jobs:
     permissions:
       issues: write
     steps:
-      - run: npm install yaml
+      - name: Install dependencies
+        timeout-minutes: 2
+        run: for i in 1 2 3; do npm install yaml && break || sleep 15; done
 
       - name: Calculate and create task
         uses: actions/github-script@v8


### PR DESCRIPTION
## Summary
- Add 3-attempt retry with 15s sleep between attempts to all `npm ci`/`npm install` calls
- Handles transient npm registry failures gracefully
- Increased timeout-minutes from 1 to 2 to accommodate retries

## Files changed
- `.github/workflows/ci-cd-pr.yml` (7 instances)
- `.github/workflows/ci-cd-main.yml` (5 instances)
- `.github/workflows/ci-cd-pr-clean.yml` (1 instance)
- `.github/workflows/copilot-setup-steps.yml` (1 instance)
- `.github/workflows/janitor.yml` (1 instance)

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/321)**

<!-- codjiflo-link -->