### PR TITLE
fix(e2e): wait for iteration loading in minimap lasso tests

### DIFF
--- a/e2e/mock/iteration-mode/minimap-lasso-sizing.spec.ts
+++ b/e2e/mock/iteration-mode/minimap-lasso-sizing.spec.ts
@@ -119,6 +119,12 @@ diff --git a/src/large-file.ts b/src/large-file.ts
       page.getByRole("heading", { name: "src/large-file.ts" })
     ).toBeVisible();
 
+    // Wait for iteration artifact to finish loading before measuring lasso positions
+    // Without this, the diff data can change mid-test causing lasso positions to shift
+    await expect(
+      page.getByRole("button", { name: /Iteration \d+/ })
+    ).toBeVisible();
+
     // Enable full file mode and wait for it to take effect
     await page.keyboard.press("f");
     await expect(page.getByText("Full File")).toBeVisible();
@@ -217,6 +223,11 @@ diff --git a/src/large-file.ts b/src/large-file.ts
       page.getByRole("heading", { name: "src/large-file.ts" })
     ).toBeVisible();
 
+    // Wait for iteration artifact to finish loading
+    await expect(
+      page.getByRole("button", { name: /Iteration \d+/ })
+    ).toBeVisible();
+
     // Enable full file mode and wait for it to take effect
     await page.keyboard.press("f");
     // Wait for toolbar to show "Full File" label (indicating full-file mode is active)
@@ -258,6 +269,11 @@ diff --git a/src/large-file.ts b/src/large-file.ts
 
     await expect(
       page.getByRole("heading", { name: "src/large-file.ts" })
+    ).toBeVisible();
+
+    // Wait for iteration artifact to finish loading
+    await expect(
+      page.getByRole("button", { name: /Iteration \d+/ })
     ).toBeVisible();
 
     // Enable full file mode and wait for it to take effect


### PR DESCRIPTION
## Summary
- Fix flaky E2E test in `minimap-lasso-sizing.spec.ts` by waiting for iteration artifact to load before measuring lasso positions
- Root cause: iteration data loading mid-test caused diff content to change, shifting lasso positions unexpectedly

## Root Cause Analysis
The test measured lasso positions at different scroll points but didn't wait for the iteration artifact to finish loading. DOM snapshots revealed:

| Timing | Iteration Selector | File Stats |
|--------|-------------------|------------|
| After "middle" click | `"loading"` | "1 additions, 0 deletions" |
| After "bottom" click | `"Iteration 1 (Jan 2)"` | "3 additions, 2 deletions" |

When the artifact loaded between measurements, the diff data changed completely (from patch-based to iteration-based), causing the minimap to recalculate.

## Test plan
- [x] Reproduced flaky failure: 6/10 failures before fix
- [x] Verified fix: 10/10 passes after fix
- [x] Full test suite passes (`npm run test:all`)

Fixes #324

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/328)**

<!-- codjiflo-link -->