### PR TITLE
feat(auth): implement unauthenticated landing flow (S-4.1.1)

### DIFF
--- a/e2e/common/degraded-mode/app.spec.ts
+++ b/e2e/common/degraded-mode/app.spec.ts
@@ -8,10 +8,12 @@ test.describe("CodjiFlo App", () => {
     await setupLegacyDefaults(page);
   });
 
-  test("should redirect unauthenticated users to login", async ({ page }) => {
+  test("should show dashboard for unauthenticated users", async ({ page }) => {
     await page.goto("/");
-    await expect(page).toHaveURL(/.*\/login/);
-    await expect(page.getByRole("heading", { name: /Connect to GitHub/i })).toBeVisible();
+    await expect(page).toHaveURL(/.*\/dashboard/);
+    await expect(page.getByRole("heading", { name: /View Pull Request/i })).toBeVisible();
+    // Login button should be visible for unauthenticated users
+    await expect(page.getByRole("button", { name: /Log in with GitHub/i })).toBeVisible();
   });
 
   test("should show dashboard when authenticated", async ({ page }) => {

--- a/e2e/common/degraded-mode/authentication-flow.spec.ts
+++ b/e2e/common/degraded-mode/authentication-flow.spec.ts
@@ -16,8 +16,8 @@ test.describe("Authentication Flow (S-1.1)", () => {
   test("Complete authentication journey - successful login and session persistence", async ({
     page,
   }) => {
-    // [AC-1.1.1] User sees "Connect to GitHub" screen when not authenticated
-    await page.goto("/");
+    // [AC-1.1.1] User sees "Connect to GitHub" screen when navigating to login
+    await page.goto("/login");
     await expect(
       page.getByRole("heading", { name: /Connect to GitHub/i })
     ).toBeVisible();

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,21 +1,22 @@
 'use client';
 
 import { useState, FormEvent, Suspense } from 'react';
-import { useRouter } from 'next/navigation';
-import { LogOut } from 'lucide-react';
+import { useRouter, usePathname } from 'next/navigation';
+import { LogOut, LogIn } from 'lucide-react';
 import { Input } from '@/components/Input';
 import { Button } from '@/components/Button';
 import { parseGitHubPRUrl } from '@/features/pr';
 import { useAuthStore } from '@/features/auth/stores/useAuthStore';
-import { useRequireAuth } from '@/features/auth/hooks';
+import { useOptionalAuth } from '@/features/auth/hooks';
 import { AppShell, Titlebar } from '@/components/layout';
 
 function DashboardContent() {
   const [url, setUrl] = useState('');
   const [error, setError] = useState('');
   const router = useRouter();
+  const pathname = usePathname();
   const logout = useAuthStore((s) => s.logout);
-  const { isAuthenticated } = useRequireAuth();
+  const { isAuthenticated, isLoading } = useOptionalAuth();
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -32,10 +33,15 @@ function DashboardContent() {
 
   const handleLogout = () => {
     logout();
-    router.replace('/login');
+    router.replace('/dashboard');
   };
 
-  if (!isAuthenticated) {
+  const handleLogin = () => {
+    const returnPath = encodeURIComponent(pathname);
+    router.push(`/login?returnPath=${returnPath}`);
+  };
+
+  if (isLoading) {
     return null;
   }
 
@@ -44,14 +50,27 @@ function DashboardContent() {
       <Titlebar
         title="Dashboard"
         rightContent={
-          <button
-            onClick={handleLogout}
-            className="btn-nav"
-            aria-label="Logout"
-            style={{ marginRight: '8px' }}
-          >
-            <LogOut size={16} />
-          </button>
+          isAuthenticated ? (
+            <button
+              onClick={handleLogout}
+              className="btn-nav"
+              title="Logout"
+              aria-label="Logout"
+              style={{ marginRight: '8px' }}
+            >
+              <LogOut size={16} />
+            </button>
+          ) : (
+            <button
+              onClick={handleLogin}
+              className="btn-nav"
+              title="Log in with GitHub"
+              aria-label="Log in with GitHub"
+              style={{ marginRight: '8px' }}
+            >
+              <LogIn size={16} />
+            </button>
+          )
         }
       />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,18 +2,15 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { useAuthStore } from '@/features/auth/stores/useAuthStore';
 
 export default function Home() {
   const router = useRouter();
-  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
 
   useEffect(() => {
-    // Home page redirects based on auth status
-    // Note: This may flash briefly for authenticated users before hydration,
-    // but the login page handles redirecting authenticated users to dashboard
-    router.replace(isAuthenticated ? '/dashboard' : '/login');
-  }, [isAuthenticated, router]);
+    // Root path always redirects to dashboard regardless of auth status
+    // The dashboard is accessible to both authenticated and unauthenticated users
+    router.replace('/dashboard');
+  }, [router]);
 
   return (
     <div>

--- a/src/features/auth/hooks/index.ts
+++ b/src/features/auth/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useOAuthFlow } from './useOAuthFlow';
 export { useTokenRefresh, refreshTokenBeforeApiCall } from './useTokenRefresh';
 export { useRequireAuth, useRedirectIfAuthenticated } from './useRequireAuth';
+export { useOptionalAuth } from './useOptionalAuth';

--- a/src/features/auth/hooks/useOptionalAuth.test.ts
+++ b/src/features/auth/hooks/useOptionalAuth.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useOptionalAuth } from './useOptionalAuth';
+import { useAuthStore } from '../stores/useAuthStore';
+
+// Mock the auth store
+vi.mock('../stores/useAuthStore', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+// Helper to mock useAuthStore with a partial state
+function mockAuthStore(partialState: {
+  isAuthenticated: boolean;
+  hasHydrated?: boolean;
+  token?: string | null;
+}) {
+  const state = { hasHydrated: true, token: null, ...partialState };
+  (useAuthStore as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+    <T,>(selector: (state: { isAuthenticated: boolean; hasHydrated: boolean; token: string | null }) => T) =>
+      selector(state)
+  );
+}
+
+describe('useOptionalAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return isAuthenticated true when authenticated', () => {
+    mockAuthStore({ isAuthenticated: true, token: 'ghp_test' });
+
+    const { result } = renderHook(() => useOptionalAuth());
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.token).toBe('ghp_test');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return isAuthenticated false when not authenticated', () => {
+    mockAuthStore({ isAuthenticated: false });
+
+    const { result } = renderHook(() => useOptionalAuth());
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.token).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('should return isLoading true when not hydrated', () => {
+    mockAuthStore({ isAuthenticated: false, hasHydrated: false });
+
+    const { result } = renderHook(() => useOptionalAuth());
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('should return token when authenticated', () => {
+    mockAuthStore({ isAuthenticated: true, token: 'github_pat_xxxx' });
+
+    const { result } = renderHook(() => useOptionalAuth());
+
+    expect(result.current.token).toBe('github_pat_xxxx');
+  });
+
+  it('should return null token when not authenticated', () => {
+    mockAuthStore({ isAuthenticated: false, token: null });
+
+    const { result } = renderHook(() => useOptionalAuth());
+
+    expect(result.current.token).toBeNull();
+  });
+
+  it('should never trigger any redirects', () => {
+    // This test verifies the core difference from useRequireAuth:
+    // useOptionalAuth should NEVER redirect, regardless of auth state
+    mockAuthStore({ isAuthenticated: false, hasHydrated: true });
+
+    // The hook doesn't use router, so there's nothing to mock or check
+    // This test documents the expected behavior
+    const { result } = renderHook(() => useOptionalAuth());
+
+    expect(result.current.isAuthenticated).toBe(false);
+    // No redirect occurred - component using this hook decides what to show
+  });
+});

--- a/src/features/auth/hooks/useOptionalAuth.ts
+++ b/src/features/auth/hooks/useOptionalAuth.ts
@@ -1,0 +1,40 @@
+import { useAuthStore } from '../stores/useAuthStore';
+
+/**
+ * Hook for pages that work without authentication.
+ * Returns authentication state without redirecting unauthenticated users.
+ *
+ * Use this for pages that should be accessible to both authenticated
+ * and unauthenticated users, like the dashboard or public PR pages.
+ *
+ * @returns Object with isAuthenticated status, isLoading state, and current token
+ *
+ * @example
+ * ```tsx
+ * function DashboardPage() {
+ *   const { isAuthenticated, isLoading, token } = useOptionalAuth();
+ *
+ *   if (isLoading) {
+ *     return <LoadingSpinner />;
+ *   }
+ *
+ *   return (
+ *     <div>
+ *       {isAuthenticated ? <UserMenu /> : <LoginButton />}
+ *       <Content />
+ *     </div>
+ *   );
+ * }
+ * ```
+ */
+export function useOptionalAuth() {
+  const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
+  const hasHydrated = useAuthStore((state) => state.hasHydrated);
+  const token = useAuthStore((state) => state.token);
+
+  return {
+    isAuthenticated,
+    isLoading: !hasHydrated,
+    token,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `useOptionalAuth()` hook that returns auth state without redirecting unauthenticated users
- Root path (`/`) now redirects to `/dashboard` regardless of auth status
- Dashboard shows login button (with returnPath) for unauthenticated users, logout button for authenticated users

## Acceptance Criteria (S-4.1.1)
- ✅ AC-4.1.1.1: Root path redirects to `/dashboard` regardless of auth status
- ✅ AC-4.1.1.2: Dashboard uses `useOptionalAuth()` instead of `useRequireAuth()`
- ✅ AC-4.1.1.3: Dashboard displays PR URL input for both auth states
- ✅ AC-4.1.1.4: Login button displayed in header for unauthenticated users
- ✅ AC-4.1.1.5: Login button navigates to `/login?returnPath=...`
- ✅ AC-4.1.1.6: Logout button shown for authenticated users (preserved)
- ✅ AC-4.1.1.7: `useOptionalAuth()` returns `{ isAuthenticated, isLoading, token }`
- ✅ AC-4.1.1.8: Dashboard functionality identical for both user types
- ✅ AC-4.1.1.9: Login button has accessible label "Log in with GitHub"
- ✅ AC-4.1.1.10: Focus order is logical

## Test plan
- [x] Unit tests for `useOptionalAuth` hook (6 tests)
- [x] E2E test updated: "should show dashboard for unauthenticated users"
- [x] E2E test updated: authentication flow navigates to `/login` directly
- [x] Manual testing with Playwright MCP verified unauthenticated flow
- [x] `npm run test:all` passes (1357 unit tests, 107 E2E tests, 26 Storybook tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/346)**

<!-- codjiflo-link -->