### PR TITLE
feat(pr): private PR detection with contextual error pages (S-4.1.4)

### DIFF
--- a/e2e/common/stateless-mode/authentication-token-refresh.spec.ts
+++ b/e2e/common/stateless-mode/authentication-token-refresh.spec.ts
@@ -220,13 +220,15 @@ test.describe("Token Refresh Flow", () => {
     // Navigate to PR page
     await page.goto(`/${owner}/${repo}/${String(prNumber)}`);
 
-    // PR page should still load (S-4.1.2: unauthenticated access to public repos)
+    // After token refresh failure, error page is shown with login prompt (S-4.1.4)
     await expect(page).toHaveURL(new RegExp(`/${owner}/${repo}/${String(prNumber)}`));
 
-    // PR content should be visible after retry as unauthenticated
-    await expect(page.getByPlaceholder("Filter by file name")).toBeVisible();
+    // Error page should be visible with login option
+    const errorContainer = page.getByTestId("pr-error");
+    await expect(errorContainer).toBeVisible();
+    await expect(errorContainer.getByRole("heading", { level: 1 })).toBeVisible();
 
-    // Login button should be visible (user is now unauthenticated)
-    await expect(page.getByRole("link", { name: /Log in/i })).toBeVisible();
+    // Login link should be visible (user is now unauthenticated after refresh failure)
+    await expect(errorContainer.getByRole("link", { name: /log in/i })).toBeVisible();
   });
 });

--- a/e2e/mock/stateless-mode/private-pr-detection.spec.ts
+++ b/e2e/mock/stateless-mode/private-pr-detection.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect } from "@playwright/test";
+import {
+  setupAuthMock,
+  setupPRMock,
+  setupFilesMock,
+  setupCommentsMock,
+  setupIterationMocks,
+  setupAuthState,
+} from "../../fixtures/github-mocks";
+import { setupLegacyDefaults } from "../../fixtures/legacy-defaults";
+
+test.describe("Private PR Detection", () => {
+  const owner = "test";
+  const repo = "repo";
+  const prNumber = 42;
+
+  test("unauthenticated 404 shows private-repo prompt with login button", async ({
+    page,
+  }) => {
+    await setupLegacyDefaults(page);
+    await setupAuthMock(page);
+    await setupPRMock(page, owner, repo, prNumber, { failWith: 404 });
+    await setupFilesMock(page, owner, repo, prNumber, { failWith: 404 });
+    await setupCommentsMock(page, owner, repo, prNumber, { failWith: 404 });
+    await setupIterationMocks(page, owner, repo, prNumber);
+
+    await page.goto(`/${owner}/${repo}/${String(prNumber)}`);
+
+    // Error container with alert role
+    const errorContainer = page.getByTestId("pr-error");
+    await expect(errorContainer).toHaveAttribute("role", "alert");
+
+    // Lock icon should be present
+    await expect(page.getByTestId("pr-error-icon")).toBeVisible();
+
+    // Title should be an h1
+    const heading = errorContainer.getByRole("heading", { level: 1 });
+    await expect(heading).toBeVisible();
+
+    // Message should indicate private/missing
+    await expect(
+      errorContainer.getByText(/may be private or doesn.*t exist/i)
+    ).toBeVisible();
+
+    // Login button with returnPath
+    const loginButton = errorContainer.getByRole("link", {
+      name: /log in to access/i,
+    });
+    await expect(loginButton).toBeVisible();
+    const href = await loginButton.getAttribute("href");
+    expect(href).toContain("/login?returnPath=");
+    expect(href).toContain(encodeURIComponent(`/${owner}/${repo}/${String(prNumber)}`));
+
+    // Login button should have focus
+    await expect(loginButton).toBeFocused();
+
+    // Back to Dashboard link
+    await expect(
+      errorContainer.getByRole("link", { name: /back to dashboard/i })
+    ).toBeVisible();
+  });
+
+  test("authenticated 404 shows not-found without login prompt", async ({
+    page,
+  }) => {
+    await setupLegacyDefaults(page);
+    await setupAuthState(page);
+    await setupAuthMock(page);
+    await setupPRMock(page, owner, repo, prNumber, { failWith: 404 });
+    await setupFilesMock(page, owner, repo, prNumber, { failWith: 404 });
+    await setupCommentsMock(page, owner, repo, prNumber, { failWith: 404 });
+    await setupIterationMocks(page, owner, repo, prNumber);
+
+    await page.goto(`/${owner}/${repo}/${String(prNumber)}`);
+
+    const errorContainer = page.getByTestId("pr-error");
+    await expect(errorContainer).toHaveAttribute("role", "alert");
+
+    // Should say "not found" (not "may be private")
+    await expect(
+      errorContainer.getByRole("heading", { name: /pull request not found/i })
+    ).toBeVisible();
+
+    // No login button
+    await expect(
+      errorContainer.getByRole("link", { name: /log in/i })
+    ).toBeHidden();
+
+    // Back to Dashboard link
+    await expect(
+      errorContainer.getByRole("link", { name: /back to dashboard/i })
+    ).toBeVisible();
+  });
+
+  test("unauthenticated 403 shows permission error with login option", async ({
+    page,
+  }) => {
+    await setupLegacyDefaults(page);
+    await setupAuthMock(page);
+    await setupPRMock(page, owner, repo, prNumber, { failWith: 403 });
+    await setupFilesMock(page, owner, repo, prNumber, { failWith: 403 });
+    await setupCommentsMock(page, owner, repo, prNumber, { failWith: 403 });
+    await setupIterationMocks(page, owner, repo, prNumber);
+
+    await page.goto(`/${owner}/${repo}/${String(prNumber)}`);
+
+    const errorContainer = page.getByTestId("pr-error");
+    await expect(errorContainer).toHaveAttribute("role", "alert");
+
+    // Unauthenticated 403 is treated as private-repo (isPrivateRepo flag set by client)
+    await expect(
+      errorContainer.getByText(/may be private or doesn.*t exist/i)
+    ).toBeVisible();
+
+    // Login option
+    const loginButton = errorContainer.getByRole("link", {
+      name: /log in to access/i,
+    });
+    await expect(loginButton).toBeVisible();
+    await expect(loginButton).toBeFocused();
+  });
+
+  test("authenticated 403 shows permission error without login button", async ({
+    page,
+  }) => {
+    await setupLegacyDefaults(page);
+    await setupAuthState(page);
+    await setupAuthMock(page);
+    await setupPRMock(page, owner, repo, prNumber, { failWith: 403 });
+    await setupFilesMock(page, owner, repo, prNumber, { failWith: 403 });
+    await setupCommentsMock(page, owner, repo, prNumber, { failWith: 403 });
+    await setupIterationMocks(page, owner, repo, prNumber);
+
+    await page.goto(`/${owner}/${repo}/${String(prNumber)}`);
+
+    const errorContainer = page.getByTestId("pr-error");
+    await expect(errorContainer).toHaveAttribute("role", "alert");
+
+    // Permission message with request access guidance
+    await expect(
+      errorContainer.getByText(/don.*t have permission.*request access/i)
+    ).toBeVisible();
+
+    // No login button
+    await expect(
+      errorContainer.getByRole("link", { name: /log in/i })
+    ).toBeHidden();
+  });
+});

--- a/src/app/[owner]/[repo]/[number]/page.tsx
+++ b/src/app/[owner]/[repo]/[number]/page.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect, useState, useCallback, use, Suspense } from 'react';
+import { useEffect, useState, useCallback, use, Suspense, useRef } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ArrowLeft, Keyboard, LogIn, LogOut } from 'lucide-react';
+import Link from 'next/link';
+import { ArrowLeft, Keyboard, Lock, LogIn, LogOut } from 'lucide-react';
 import { usePRStore, useDocumentTitle } from '@/features/pr';
+import type { PRError } from '@/features/pr/types';
 import { useDiffStore, FileList, DiffView } from '@/features/diff';
 import { useKeyboardShortcuts, ShortcutsModal } from '@/features/keyboard';
 import { useCommentsStore } from '@/features/comments';
@@ -40,7 +42,7 @@ function PullRequestContent({ params }: PRPageProps) {
   const queryString = searchParams.toString();
   const returnPath = queryString ? `${basePath}?${queryString}` : basePath;
 
-  const { currentPR, loadPR, reset: resetPR } = usePRStore();
+  const { currentPR, error: prError, loadPR, reset: resetPR } = usePRStore();
   const { loadFiles, reset: resetDiff } = useDiffStore();
   const { threads, loadThreads, reset: resetComments } = useCommentsStore();
   const { loadIterations, reset: resetIterations } = useIterationStore();
@@ -117,6 +119,18 @@ function PullRequestContent({ params }: PRPageProps) {
             Back to Dashboard
           </button>
         </div>
+      </AppShell>
+    );
+  }
+
+  if (prError) {
+    return (
+      <AppShell>
+        <PRErrorView
+          error={prError}
+          isAuthenticated={isAuthenticated}
+          returnPath={returnPath}
+        />
       </AppShell>
     );
   }
@@ -232,6 +246,61 @@ function PullRequestContent({ params }: PRPageProps) {
         onClose={() => setShowShortcuts(false)}
       />
     </AppShell>
+  );
+}
+
+function PRErrorView({ error, isAuthenticated, returnPath }: {
+  error: PRError;
+  isAuthenticated: boolean;
+  returnPath: string;
+}) {
+  const loginRef = useRef<HTMLAnchorElement>(null);
+  const { kind, message } = error;
+  const showLogin = !isAuthenticated && (kind === 'private-repo' || kind === 'forbidden');
+  const loginHref = `/login?returnPath=${encodeURIComponent(returnPath)}`;
+
+  const title = kind === 'not-found' ? 'Pull Request Not Found'
+    : kind === 'private-repo' && isAuthenticated ? 'Pull Request Not Found'
+    : kind === 'private-repo' ? 'Access Required'
+    : kind === 'forbidden' ? 'Access Denied'
+    : 'Error';
+
+  const description = kind === 'private-repo' && !isAuthenticated
+    ? 'This PR may be private or doesn\'t exist. Log in to access private repositories.'
+    : kind === 'forbidden' && isAuthenticated
+    ? 'You don\'t have permission to view this pull request. Request access from the repository owner.'
+    : kind === 'forbidden' && !isAuthenticated
+    ? 'You don\'t have permission to view this pull request.'
+    : message;
+
+  useEffect(() => {
+    loginRef.current?.focus();
+  }, []);
+
+  return (
+    <div className="pr-error-container" role="alert" aria-live="polite" data-testid="pr-error">
+      <div className="pr-error-card">
+        <div className="pr-error-icon" data-testid="pr-error-icon">
+          <Lock size={48} />
+        </div>
+        <h1 className="pr-error-title">{title}</h1>
+        <p className="pr-error-message">{description}</p>
+        <div className="pr-error-actions">
+          {showLogin && (
+            <a
+              ref={loginRef}
+              href={loginHref}
+              className="btn btn-colorful"
+            >
+              Log in to access
+            </a>
+          )}
+          <Link href="/dashboard" className="btn-link">
+            Back to Dashboard
+          </Link>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,6 +23,7 @@
 @import '../styles/pages/login.css';
 @import '../styles/pages/dashboard.css';
 @import '../styles/pages/auth-status.css';
+@import '../styles/pages/pr-error.css';
 
 /* Modal Styles */
 @import '../styles/modals/modal-base.css';

--- a/src/features/pr/components/PRHeader.test.tsx
+++ b/src/features/pr/components/PRHeader.test.tsx
@@ -17,7 +17,7 @@ describe('PRHeader', () => {
     vi.mocked(usePRStore).mockReturnValue({
       currentPR: null,
       isLoading: false,
-      error: 'Failed to load PR',
+      error: { message: 'Failed to load PR', kind: 'generic' as const },
     });
 
     render(<PRHeader />);

--- a/src/features/pr/components/PRHeader.tsx
+++ b/src/features/pr/components/PRHeader.tsx
@@ -12,7 +12,7 @@ export function PRHeader() {
   if (error) {
     return (
       <div className="pr-header pr-header-error" role="alert" aria-live="polite">
-        <p className="error-text">{error}</p>
+        <p className="error-text">{error.message}</p>
       </div>
     );
   }

--- a/src/features/pr/stores/usePRStore.test.ts
+++ b/src/features/pr/stores/usePRStore.test.ts
@@ -19,6 +19,7 @@ vi.mock('@/api', () => {
       },
     },
     GitHubAPIError: class GitHubAPIError extends Error {
+      isPrivateRepo?: boolean;
       constructor(public status: number, public statusText: string, message: string) {
         super(message);
         this.name = 'GitHubAPIError';
@@ -80,46 +81,97 @@ describe('usePRStore', () => {
       await loadPromise;
     });
 
-    it('handles 404 error', async () => {
+    it('handles 404 error without isPrivateRepo as not-found', async () => {
       mockGetReview.mockRejectedValue(
         new api.GitHubAPIError(404, 'Not Found', 'Not Found')
       );
 
       await usePRStore.getState().loadPR('owner', 'repo', 999);
 
-      expect(usePRStore.getState().error).toBe('Pull request not found. Please check the URL.');
+      expect(usePRStore.getState().error).toEqual({
+        message: 'Pull request not found.',
+        kind: 'not-found',
+      });
       expect(usePRStore.getState().currentPR).toBeNull();
       expect(usePRStore.getState().isLoading).toBe(false);
     });
 
-    it('handles 401/403 authorization error', async () => {
+    it('handles 404 error with isPrivateRepo as private-repo', async () => {
+      const err = new api.GitHubAPIError(404, 'Not Found', 'Not Found');
+      err.isPrivateRepo = true;
+      mockGetReview.mockRejectedValue(err);
+
+      await usePRStore.getState().loadPR('owner', 'repo', 999);
+
+      expect(usePRStore.getState().error).toEqual({
+        message: "This PR may be private or doesn't exist.",
+        kind: 'private-repo',
+      });
+    });
+
+    it('handles 401 error as forbidden', async () => {
       mockGetReview.mockRejectedValue(
-        new api.GitHubAPIError(401, 'Unauthorized', 'Unauthorized')
+        new api.GitHubAPIError(401, 'Unauthorized', 'Session expired. Please log in again.')
       );
 
       await usePRStore.getState().loadPR('owner', 'repo', 123);
 
-      expect(usePRStore.getState().error).toBe('Access denied. Please check your token permissions.');
+      expect(usePRStore.getState().error).toEqual({
+        message: 'Session expired. Please log in again.',
+        kind: 'forbidden',
+      });
     });
 
-    it('handles other GitHubAPIError status codes', async () => {
+    it('handles 403 error without isPrivateRepo as forbidden', async () => {
+      mockGetReview.mockRejectedValue(
+        new api.GitHubAPIError(403, 'Forbidden', 'Forbidden')
+      );
+
+      await usePRStore.getState().loadPR('owner', 'repo', 123);
+
+      expect(usePRStore.getState().error).toEqual({
+        message: "You don't have permission to view this pull request.",
+        kind: 'forbidden',
+      });
+    });
+
+    it('handles 403 error with isPrivateRepo as private-repo', async () => {
+      const err = new api.GitHubAPIError(403, 'Forbidden', 'Forbidden');
+      err.isPrivateRepo = true;
+      mockGetReview.mockRejectedValue(err);
+
+      await usePRStore.getState().loadPR('owner', 'repo', 123);
+
+      expect(usePRStore.getState().error).toEqual({
+        message: "This PR may be private or doesn't exist.",
+        kind: 'private-repo',
+      });
+    });
+
+    it('handles other GitHubAPIError status codes as generic', async () => {
       mockGetReview.mockRejectedValue(
         new api.GitHubAPIError(500, 'Internal Server Error', 'Server error occurred')
       );
 
       await usePRStore.getState().loadPR('owner', 'repo', 123);
 
-      expect(usePRStore.getState().error).toBe('Server error occurred');
+      expect(usePRStore.getState().error).toEqual({
+        message: 'Server error occurred',
+        kind: 'generic',
+      });
       expect(usePRStore.getState().currentPR).toBeNull();
       expect(usePRStore.getState().isLoading).toBe(false);
     });
 
-    it('handles regular Error instances', async () => {
+    it('handles regular Error instances as generic', async () => {
       mockGetReview.mockRejectedValue(new Error('Network failure'));
 
       await usePRStore.getState().loadPR('owner', 'repo', 123);
 
-      expect(usePRStore.getState().error).toBe('Network failure');
+      expect(usePRStore.getState().error).toEqual({
+        message: 'Network failure',
+        kind: 'generic',
+      });
       expect(usePRStore.getState().currentPR).toBeNull();
       expect(usePRStore.getState().isLoading).toBe(false);
     });
@@ -131,7 +183,7 @@ describe('usePRStore', () => {
       usePRStore.setState({
         currentPR: { id: 1 } as never,
         isLoading: true,
-        error: 'Some error',
+        error: { message: 'Some error', kind: 'generic' as const },
       });
 
       usePRStore.getState().reset();
@@ -144,7 +196,7 @@ describe('usePRStore', () => {
 
   describe('clearError', () => {
     it('clears the error', () => {
-      usePRStore.setState({ error: 'Some error' });
+      usePRStore.setState({ error: { message: 'Some error', kind: 'generic' as const } });
 
       usePRStore.getState().clearError();
 

--- a/src/features/pr/stores/usePRStore.ts
+++ b/src/features/pr/stores/usePRStore.ts
@@ -14,12 +14,24 @@ export const usePRStore = create<PRState>((set) => ({
       set({ currentPR: pr, isLoading: false });
     } catch (err) {
       let message = 'Failed to load pull request';
+      let kind: import('../types').PRErrorKind = 'generic';
 
       if (err instanceof GitHubAPIError) {
-        if (err.status === 404) {
-          message = 'Pull request not found. Please check the URL.';
-        } else if (err.status === 401 || err.status === 403) {
-          message = 'Access denied. Please check your token permissions.';
+        if (err.status === 404 && err.isPrivateRepo) {
+          message = 'This PR may be private or doesn\'t exist.';
+          kind = 'private-repo';
+        } else if (err.status === 404) {
+          message = 'Pull request not found.';
+          kind = 'not-found';
+        } else if (err.status === 403 && err.isPrivateRepo) {
+          message = 'This PR may be private or doesn\'t exist.';
+          kind = 'private-repo';
+        } else if (err.status === 401) {
+          message = err.message;
+          kind = 'forbidden';
+        } else if (err.status === 403) {
+          message = 'You don\'t have permission to view this pull request.';
+          kind = 'forbidden';
         } else {
           message = err.message;
         }
@@ -27,7 +39,7 @@ export const usePRStore = create<PRState>((set) => ({
         message = err.message;
       }
 
-      set({ error: message, isLoading: false, currentPR: null });
+      set({ error: { message, kind }, isLoading: false, currentPR: null });
     }
   },
 

--- a/src/features/pr/types.ts
+++ b/src/features/pr/types.ts
@@ -1,9 +1,16 @@
 import type { Review } from '@/api/types';
 
+export type PRErrorKind = 'not-found' | 'private-repo' | 'forbidden' | 'generic';
+
+export interface PRError {
+  message: string;
+  kind: PRErrorKind;
+}
+
 export interface PRState {
   currentPR: Review | null;
   isLoading: boolean;
-  error: string | null;
+  error: PRError | null;
   loadPR: (owner: string, repo: string, number: number) => Promise<void>;
   clearError: () => void;
   reset: () => void;

--- a/src/styles/pages/pr-error.css
+++ b/src/styles/pages/pr-error.css
@@ -1,0 +1,45 @@
+/* ============================================
+   PR ERROR PAGES (Private repo, not found, etc.)
+   ============================================ */
+.pr-error-container {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.pr-error-card {
+  background-color: var(--control-bg);
+  border: 1px solid var(--combobox-border);
+  border-radius: 4px;
+  padding: 32px;
+  text-align: center;
+  min-width: 300px;
+  max-width: 440px;
+}
+
+.pr-error-icon {
+  color: var(--control-disabled-fg);
+  margin-bottom: 16px;
+}
+
+.pr-error-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--fg);
+  margin: 0 0 8px 0;
+}
+
+.pr-error-message {
+  color: var(--control-disabled-fg);
+  margin: 0 0 24px 0;
+  line-height: 1.5;
+}
+
+.pr-error-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}


### PR DESCRIPTION
## Summary
- Detect 404/403 errors when loading PRs, distinguish private-repo vs not-found scenarios
- Show contextual error pages with lock icon, login prompts (with `returnPath`), and accessibility attributes
- Add `PRErrorKind` union type and structured `PRError` object replacing plain string errors
- Classify errors in `usePRStore` using `isPrivateRepo` flag from `GitHubAPIError`
- Handle 401 (session expired) as forbidden kind to show login prompts after token refresh failure

## Test plan
- [x] 11 unit tests in `usePRStore.test.ts` covering all error classification paths (404/403/401 with/without `isPrivateRepo`)
- [x] 4 new E2E tests in `private-pr-detection.spec.ts` (unauthenticated 404, authenticated 404, unauthenticated 403, authenticated 403)
- [x] Updated `PRHeader.test.tsx` for new error structure
- [x] Updated `authentication-token-refresh.spec.ts` for new error page rendering after refresh failure
- [x] TDD validated: E2E tests written first and confirmed failing before product code
- [x] `npm run test:all` passes (lint + typecheck + 1366 unit tests + 109 E2E tests + 26 storybook tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/354)**

<!-- codjiflo-link -->