### PR TITLE
fix: correct worktree port calculation and add SSL CA support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "postinstall": "node scripts/copy-sql-wasm.js",
     "dev": "node scripts/dev.js",
-    "build": "next build",
-    "start": "next start",
+    "build": "cross-env NODE_OPTIONS=--use-system-ca next build",
+    "start": "cross-env NODE_OPTIONS=--use-system-ca next start",
     "lint": "eslint . --fix --quiet --max-warnings 0 --prune-suppressions",
     "lint:check": "eslint . --quiet --max-warnings 0",
     "storybook": "storybook dev -p 6006 --quiet",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -81,7 +81,7 @@ function getPortForWorktree() {
   // Check if directory name is a single uppercase letter A-Z
   if (/^[A-Z]$/.test(dirName)) {
     const letter = dirName.charCodeAt(0); // ASCII code
-    const port = 3000 + (letter - 65) * 10; // A=3010, B=3020, ...
+    const port = 3010 + (letter - 65) * 10; // A=3010, B=3020, ...
     return { port, strict: true };
   }
   


### PR DESCRIPTION
## Summary
- Fix dev.js port formula to correctly map worktree directories (A=3010, B=3020, etc.)
- Add `--use-system-ca` NODE_OPTIONS to build/start scripts to resolve SSL certificate verification errors

## Test plan
- [x] Verified worktree B now starts on port 3020
- [x] E2E tests pass without SSL errors (105/105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/359)**

<!-- codjiflo-link -->