### PR TITLE
chore: add Letta agent config files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ public/sql-wasm/
 tmpclaude-*
 trace-export/
 demos/
+
+# Letta agent configuration
+.letta/
+.claude/CLAUDE.md


### PR DESCRIPTION
## Summary
- Add `.letta/` directory to gitignore
- Add `.claude/CLAUDE.md` to gitignore (Letta memory sync file)

These are auto-generated by the Letta subconscious memory system and should not be tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/361)**

<!-- codjiflo-link -->