### PR TITLE
Harden dev script zombie detection per PR #387 review

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -69,7 +69,7 @@ function findZombiePidsWindows() {
     `$projectPath = '${escapedProjectPathForPwsh}'; ` +
     `$escapedProjectPath = [regex]::Escape($projectPath); ` +
     "Get-CimInstance Win32_Process | " +
-    "Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -match $escapedProjectPath -and $_.CommandLine -match 'next\\s+dev' } | " +
+    "Where-Object { $_.Name -eq 'node.exe' -and $_.CommandLine -match $escapedProjectPath -and $_.CommandLine -match 'next\\W+dev' } | " +
     "Select-Object -ExpandProperty ProcessId";
   try {
     const output = execSync(`pwsh.exe -NoProfile -Command "${psCommand}"`, {


### PR DESCRIPTION
## Summary
Follow-up to #387, addressing Copilot review feedback:
- Use `[regex]::Escape()` for PowerShell path matching to handle metacharacters
- Use `execFileSync` instead of shell pipeline for Unix PID detection to avoid injection
- Tighten process matching to `next dev` only, preventing accidental kills of tests/scripts
- Kill entire process tree on Unix (`killProcessTree`) so child `next-server` releases the port immediately

## Test plan
- [x] Dev server starts cleanly from clean state (no warnings, correct port)
- [x] Zombie detection finds exactly 1 process (the `next dev` node process) — no false positives
- [x] Zombie kill releases port on first try (process tree kill gets child `next-server`)
- [x] Worktree A processes are not matched when running from worktree B

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/388)**

<!-- codjiflo-link -->