### PR TITLE
Fix ESLint consistent-indexed-object-style errors

### DIFF
--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -5,14 +5,14 @@ interface BadgeProps {
   className?: string;
 }
 
-const STATE_CSS_CLASSES: Record<ReviewState, string> = {
+const STATE_CSS_CLASSES: { [K in ReviewState]: string } = {
   [ReviewState.Open]: 'badge badge-success',
   [ReviewState.Closed]: 'badge badge-error',
   [ReviewState.Merged]: 'badge badge-merged',
   [ReviewState.Draft]: 'badge',
 };
 
-const STATE_LABELS: Record<ReviewState, string> = {
+const STATE_LABELS: { [K in ReviewState]: string } = {
   [ReviewState.Open]: 'Open',
   [ReviewState.Closed]: 'Closed',
   [ReviewState.Merged]: 'Merged',

--- a/src/features/diff/components/DiffEmptyState.tsx
+++ b/src/features/diff/components/DiffEmptyState.tsx
@@ -14,7 +14,7 @@ interface DiffEmptyStateProps {
 /**
  * Empty state messages for different scenarios.
  */
-const EMPTY_STATE_MESSAGES: Record<DiffEmptyStateVariant, { title: string; subtitle?: string }> = {
+const EMPTY_STATE_MESSAGES: { [K in DiffEmptyStateVariant]: { title: string; subtitle?: string } } = {
   'no-file': {
     title: 'Select a file to view diff',
   },

--- a/src/features/diff/components/DiffToolbar.tsx
+++ b/src/features/diff/components/DiffToolbar.tsx
@@ -205,7 +205,7 @@ function ToolbarSelect<T extends string>({ value, onChange, options, ariaLabel, 
 
 // Content filter constants (defined outside component to avoid recreation on each render)
 const FILTER_POSITIONS: ContentFilter[] = ['left', 'both', 'right'];
-const FILTER_LABELS: Record<ContentFilter, string> = {
+const FILTER_LABELS: { [K in ContentFilter]: string } = {
   left: 'Left Only',
   both: 'Show Both',
   right: 'Right Only',
@@ -222,7 +222,7 @@ function ContentFilterSlider({ value, onChange }: ContentFilterSliderProps) {
   const [isDragging, setIsDragging] = useState(false);
 
   // Dynamic tooltip hints based on current position
-  const dragHints: Record<ContentFilter, string> = {
+  const dragHints: { [K in ContentFilter]: string } = {
     left: 'Drag for Both (O) or Right Only (R)',
     both: 'Drag for Left Only (L) or Right Only (R)',
     right: 'Drag for Left Only (L) or Both (O)',

--- a/src/features/diff/components/FileListItem.tsx
+++ b/src/features/diff/components/FileListItem.tsx
@@ -1,21 +1,21 @@
 import type { FileChange } from '@/api/types';
 import { FileChangeStatus } from '@/api/types';
 
-const CHANGE_TYPE_ICONS: Record<FileChangeStatus, string> = {
+const CHANGE_TYPE_ICONS: { [K in FileChangeStatus]: string } = {
   [FileChangeStatus.Added]: 'A',
   [FileChangeStatus.Modified]: 'M',
   [FileChangeStatus.Deleted]: 'D',
   [FileChangeStatus.Renamed]: 'R',
 };
 
-const CHANGE_TYPE_CLASSES: Record<FileChangeStatus, string> = {
+const CHANGE_TYPE_CLASSES: { [K in FileChangeStatus]: string } = {
   [FileChangeStatus.Added]: 'add',
   [FileChangeStatus.Modified]: 'edit',
   [FileChangeStatus.Deleted]: 'delete',
   [FileChangeStatus.Renamed]: 'edit',
 };
 
-const CHANGE_TYPE_LABELS: Record<FileChangeStatus, string> = {
+const CHANGE_TYPE_LABELS: { [K in FileChangeStatus]: string } = {
   [FileChangeStatus.Added]: 'added',
   [FileChangeStatus.Modified]: 'modified',
   [FileChangeStatus.Deleted]: 'deleted',


### PR DESCRIPTION
## Summary
- Convert `Record<...>` types to index signatures as preferred by `@typescript-eslint/consistent-indexed-object-style` rule
- All lint checks now pass

## Test plan
- [x] `npm run lint` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/404)**

<!-- codjiflo-link -->