### PR TITLE
fix: paginate PR comments in findExistingComment

### DIFF
--- a/action/src/comment/comment-manager.test.ts
+++ b/action/src/comment/comment-manager.test.ts
@@ -3,7 +3,83 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { updatePRDescription } from './comment-manager';
+import { updatePRDescription, updatePRComment, getArtifactIdFromComment } from './comment-manager';
+
+describe('findExistingComment pagination', () => {
+  let mockOctokit: any;
+  const owner = 'testowner';
+  const repo = 'testrepo';
+  const prNumber = 123;
+
+  beforeEach(() => {
+    // Simulate 150 comments across 2 pages, with codjiflo marker on page 2
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      id: i + 1,
+      body: `unrelated comment ${i + 1}`,
+    }));
+    const page2 = [
+      ...Array.from({ length: 20 }, (_, i) => ({
+        id: 101 + i,
+        body: `unrelated comment ${101 + i}`,
+      })),
+      {
+        id: 999,
+        body: '<!-- codjiflo-data -->\n**Artifact**: `42`\n',
+      },
+      ...Array.from({ length: 29 }, (_, i) => ({
+        id: 1000 + i,
+        body: `unrelated comment ${1000 + i}`,
+      })),
+    ];
+
+    mockOctokit = {
+      rest: {
+        issues: {
+          listComments: Object.assign(
+            vi.fn(async ({ page }: { page?: number }) => {
+              if (page === 1 || page === undefined) return { data: page1 };
+              if (page === 2) return { data: page2 };
+              return { data: [] };
+            }),
+            { endpoint: { merge: vi.fn() } }
+          ),
+          createComment: vi.fn().mockResolvedValue({}),
+          updateComment: vi.fn().mockResolvedValue({}),
+        },
+      },
+      paginate: vi.fn(async (fn: any, params: any) => {
+        const results: any[] = [];
+        let page = 1;
+        while (true) {
+          const { data } = await fn({ ...params, page });
+          if (!data || data.length === 0) break;
+          results.push(...data);
+          if (data.length < (params.per_page ?? 30)) break;
+          page += 1;
+        }
+        return results;
+      }),
+    };
+  });
+
+  it('should find marker comment on page 2 via getArtifactIdFromComment', async () => {
+    const artifactId = await getArtifactIdFromComment(mockOctokit, owner, repo, prNumber);
+    expect(artifactId).toBe(42);
+  });
+
+  it('should update (not create) when marker comment exists on page 2', async () => {
+    await updatePRComment(mockOctokit, owner, repo, prNumber, {
+      iterationCount: 1,
+      runId: 1,
+      timestamp: '2026-01-01',
+      artifactId: 42,
+    });
+    expect(mockOctokit.rest.issues.updateComment).toHaveBeenCalledWith(
+      expect.objectContaining({ comment_id: 999 })
+    );
+    expect(mockOctokit.rest.issues.createComment).not.toHaveBeenCalled();
+  });
+});
 
 describe('updatePRDescription', () => {
   let mockOctokit: any;

--- a/action/src/comment/comment-manager.ts
+++ b/action/src/comment/comment-manager.ts
@@ -72,7 +72,7 @@ async function findExistingComment(
   repo: string,
   prNumber: number
 ): Promise<{ id: number; body: string } | null> {
-  const { data: comments } = await octokit.rest.issues.listComments({
+  const comments = await octokit.paginate(octokit.rest.issues.listComments, {
     owner,
     repo,
     issue_number: prNumber,


### PR DESCRIPTION
## Summary

Closes #484

`findExistingComment` in `action/src/comment/comment-manager.ts` was calling `octokit.rest.issues.listComments` with `per_page: 100` but without paginating. On PRs where CodjiFlo was added after 100+ existing comments accumulated, the marker comment at position 101+ was never found, so each action run created a duplicate marker comment.

Switched to `octokit.paginate(octokit.rest.issues.listComments, ...)` which traverses all pages.

## Test plan

- [x] New unit tests reproduce the bug (marker on "page 2" of mocked paginated results) and fail on the unfixed code
- [x] Tests pass after the fix
- [x] `npm run typecheck` passes
- [x] First commit demonstrates failing test; second commit applies the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/488)**

<!-- codjiflo-link -->