### PR TITLE
fix: dedup iterations on workflow re-runs

### DIFF
--- a/action/src/capture/iteration-capture.test.ts
+++ b/action/src/capture/iteration-capture.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Tests for captureIteration
+ *
+ * Verifies that re-running captureIteration on the same head_sha does not
+ * produce duplicate phantom iterations (issue #486).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { IterationDatabase } from '../db/database';
+import { captureIteration } from './iteration-capture';
+
+// Mock logger
+vi.mock('../utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock @actions/github so github.context.actor is defined
+vi.mock('@actions/github', () => ({
+  context: {
+    actor: 'test-actor',
+    repo: { owner: 'octo', repo: 'repo' },
+    payload: {},
+  },
+  getOctokit: vi.fn(),
+}));
+
+// Mock file-fetcher to avoid network
+vi.mock('./file-fetcher', () => ({
+  fetchFileContent: vi.fn(async () => 'file contents'),
+}));
+
+function makeOctokit() {
+  const listFiles = vi.fn();
+  // paginate just calls the method with the params and returns a fixed list
+  const paginate = vi.fn(async () => [
+    {
+      filename: 'foo.txt',
+      status: 'modified',
+      sha: 'file-sha-1',
+    },
+  ]);
+  return {
+    paginate,
+    rest: {
+      pulls: { listFiles },
+    },
+  } as unknown as Parameters<typeof captureIteration>[1]['octokit'];
+}
+
+describe('captureIteration dedup on same head_sha (issue #486)', () => {
+  let db: IterationDatabase;
+  let dbPath: string;
+
+  beforeEach(() => {
+    const tempDir = os.tmpdir();
+    dbPath = path.join(tempDir, `codjiflo-dedup-test-${Date.now()}-${Math.random()}.db`);
+    db = new IterationDatabase(dbPath);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(dbPath)) fs.unlinkSync(dbPath);
+    const walPath = dbPath + '-wal';
+    const shmPath = dbPath + '-shm';
+    if (fs.existsSync(walPath)) fs.unlinkSync(walPath);
+    if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath);
+  });
+
+  it('does not create duplicate iteration rows when run twice with same head_sha', async () => {
+    const ctx = {
+      octokit: makeOctokit(),
+      owner: 'octo',
+      repo: 'repo',
+      prNumber: 1,
+      headSha: 'deadbeef',
+      baseSha: 'basefeed',
+      beforeSha: null,
+    };
+
+    const firstId = await captureIteration(db, ctx);
+    const firstSnapshotCount = (db as unknown as {
+      db: { prepare: (sql: string) => { get: () => { count: number } } };
+    }).db.prepare('SELECT COUNT(*) as count FROM artifact_snapshots').get().count;
+
+    const secondId = await captureIteration(db, ctx);
+
+    // Only one iteration row should exist
+    expect(db.getIterationCount()).toBe(1);
+    // Second call should short-circuit and return the same iteration id
+    expect(secondId).toBe(firstId);
+
+    // No new snapshots should have been written by the second call
+    const secondSnapshotCount = (db as unknown as {
+      db: { prepare: (sql: string) => { get: () => { count: number } } };
+    }).db.prepare('SELECT COUNT(*) as count FROM artifact_snapshots').get().count;
+    expect(secondSnapshotCount).toBe(firstSnapshotCount);
+  });
+});

--- a/action/src/capture/iteration-capture.ts
+++ b/action/src/capture/iteration-capture.ts
@@ -7,6 +7,7 @@
 import * as github from '@actions/github';
 import type { IterationDatabase } from '../db/database';
 import { fetchFileContent } from './file-fetcher';
+import { logger } from '../utils/logger';
 
 // ============================================================================
 // Types
@@ -40,6 +41,21 @@ export async function captureIteration(
   db: IterationDatabase,
   ctx: CaptureContext
 ): Promise<number> {
+  // Dedup: if an iteration with this head_sha already exists, short-circuit.
+  // This prevents phantom duplicate iterations when the workflow is re-run
+  // on the same commit (e.g. "Re-run all jobs" or workflow_dispatch with the
+  // same PR_NUMBER). See issue #486.
+  const existing = db.getIterationByHeadSha(ctx.headSha);
+  if (existing) {
+    logger.info({
+      event: 'iteration_already_captured',
+      'iteration.id': existing.id,
+      'iteration.revision': existing.revision,
+      'iteration.head_sha': existing.head_sha,
+    }, 'Iteration for this head_sha already exists; skipping capture');
+    return existing.id;
+  }
+
   const iterationCount = db.getIterationCount();
   const revision = iterationCount + 1;
 

--- a/action/src/db/database.ts
+++ b/action/src/db/database.ts
@@ -107,6 +107,12 @@ export class IterationDatabase {
     `).get();
   }
 
+  getIterationByHeadSha(headSha: string): IterationRow | undefined {
+    return this.db.prepare<[string], IterationRow>(`
+      SELECT * FROM iterations WHERE head_sha = ? LIMIT 1
+    `).get(headSha);
+  }
+
   getIterationCount(): number {
     const row = this.db.prepare<[], { count: number }>(`
       SELECT COUNT(*) as count FROM iterations


### PR DESCRIPTION
Closes #486

## Summary
- `captureIteration` previously inserted a new iteration row on every run using `revision = getIterationCount() + 1`, with no `head_sha` dedup. Re-running the workflow on the same commit (via "Re-run all jobs" or `workflow_dispatch` with the same `PR_NUMBER`) created phantom duplicate iterations sharing an identical `head_sha`.
- Added `IterationDatabase.getIterationByHeadSha()` helper.
- `captureIteration` now short-circuits and returns the existing iteration id when one already exists for the given `head_sha`, skipping all snapshot work.

## Test plan
- [x] New unit test `action/src/capture/iteration-capture.test.ts` calls `captureIteration` twice with the same `headSha` and asserts:
  - `getIterationCount()` returns 1
  - both calls return the same iteration id
  - no additional `artifact_snapshots` rows are written on the second call
- [x] TDD flow: first commit adds the test and it fails (`expected 2 to be 1`). Second commit adds the fix and the full suite passes.
- [x] `npm test` and `npm run typecheck` pass in `action/`.

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/489)**

<!-- codjiflo-link -->