### PR TITLE
fix: correct line counts for added/deleted files in span tracker

### DIFF
--- a/action/src/spantracker/tracker.test.ts
+++ b/action/src/spantracker/tracker.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for SpanTracker computation.
+ *
+ * Specifically guards against off-by-one errors in the added-file and
+ * deleted-file branches when computing line counts from raw content.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { IterationDatabase } from '../db/database';
+import { computeSpanTrackers } from './tracker';
+
+// Mock logger
+vi.mock('../utils/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+interface SpanMappingRowRaw {
+  tracker_id: number;
+  left_line_start: number | null;
+  left_line_end: number | null;
+  right_line_start: number | null;
+  right_line_end: number | null;
+  mapping_type: string;
+}
+
+function getMappings(db: IterationDatabase, trackerId: number): SpanMappingRowRaw[] {
+  // Reach into the underlying better-sqlite3 instance. tracker.ts already
+  // uses the public insert API so we only need a read path for assertions.
+  const rawDb = (db as unknown as { db: import('better-sqlite3').Database }).db;
+  return rawDb
+    .prepare<[number], SpanMappingRowRaw>(
+      `SELECT * FROM span_mappings WHERE tracker_id = ? ORDER BY id`
+    )
+    .all(trackerId);
+}
+
+describe('computeSpanTrackers', () => {
+  let db: IterationDatabase;
+  let dbPath: string;
+  let artifactId: number;
+
+  beforeEach(() => {
+    const tempDir = os.tmpdir();
+    dbPath = path.join(tempDir, `codjiflo-tracker-test-${Date.now()}-${Math.random()}.db`);
+    db = new IterationDatabase(dbPath);
+    artifactId = db.getOrCreateArtifact('test-file.txt');
+  });
+
+  afterEach(() => {
+    db.close();
+    for (const suffix of ['', '-wal', '-shm']) {
+      const p = dbPath + suffix;
+      if (fs.existsSync(p)) fs.unlinkSync(p);
+    }
+  });
+
+  describe('added file (leftContent === null)', () => {
+    it('should set right_line_end to the actual line count when content ends with a trailing newline', () => {
+      const content = 'foo\nbar\nbaz\n'; // 3 lines, trailing newline
+      computeSpanTrackers(db, [
+        {
+          artifactId,
+          leftSnapshotIndex: 0,
+          rightSnapshotIndex: 1,
+          leftContent: null,
+          rightContent: content,
+        },
+      ]);
+
+      const rawDb = (db as unknown as { db: import('better-sqlite3').Database }).db;
+      const tracker = rawDb
+        .prepare<[number], { id: number }>(
+          `SELECT id FROM span_trackers WHERE artifact_id = ?`
+        )
+        .get(artifactId);
+      expect(tracker).toBeDefined();
+
+      const mappings = getMappings(db, tracker!.id);
+      expect(mappings).toHaveLength(1);
+      expect(mappings[0].mapping_type).toBe('added');
+      expect(mappings[0].right_line_start).toBe(1);
+      // The buggy implementation returns 4 here because 'foo\nbar\nbaz\n'
+      // split on '\n' yields 4 elements (with a trailing empty string).
+      expect(mappings[0].right_line_end).toBe(3);
+    });
+
+    it('should not insert a span mapping when the added file is empty', () => {
+      computeSpanTrackers(db, [
+        {
+          artifactId,
+          leftSnapshotIndex: 0,
+          rightSnapshotIndex: 1,
+          leftContent: null,
+          rightContent: '',
+        },
+      ]);
+
+      const rawDb = (db as unknown as { db: import('better-sqlite3').Database }).db;
+      const tracker = rawDb
+        .prepare<[number], { id: number }>(
+          `SELECT id FROM span_trackers WHERE artifact_id = ?`
+        )
+        .get(artifactId);
+      expect(tracker).toBeDefined();
+
+      const mappings = getMappings(db, tracker!.id);
+      // The buggy implementation inserts a phantom [1,1] mapping for empty
+      // content because ''.split('\n').length === 1.
+      expect(mappings).toHaveLength(0);
+    });
+  });
+
+  describe('deleted file (rightContent === null)', () => {
+    it('should set left_line_end to the actual line count when content ends with a trailing newline', () => {
+      const content = 'alpha\nbeta\n'; // 2 lines, trailing newline
+      computeSpanTrackers(db, [
+        {
+          artifactId,
+          leftSnapshotIndex: 0,
+          rightSnapshotIndex: 1,
+          leftContent: content,
+          rightContent: null,
+        },
+      ]);
+
+      const rawDb = (db as unknown as { db: import('better-sqlite3').Database }).db;
+      const tracker = rawDb
+        .prepare<[number], { id: number }>(
+          `SELECT id FROM span_trackers WHERE artifact_id = ?`
+        )
+        .get(artifactId);
+      expect(tracker).toBeDefined();
+
+      const mappings = getMappings(db, tracker!.id);
+      expect(mappings).toHaveLength(1);
+      expect(mappings[0].mapping_type).toBe('deleted');
+      expect(mappings[0].left_line_start).toBe(1);
+      expect(mappings[0].left_line_end).toBe(2);
+    });
+
+    it('should not insert a span mapping when the deleted file was empty', () => {
+      computeSpanTrackers(db, [
+        {
+          artifactId,
+          leftSnapshotIndex: 0,
+          rightSnapshotIndex: 1,
+          leftContent: '',
+          rightContent: null,
+        },
+      ]);
+
+      const rawDb = (db as unknown as { db: import('better-sqlite3').Database }).db;
+      const tracker = rawDb
+        .prepare<[number], { id: number }>(
+          `SELECT id FROM span_trackers WHERE artifact_id = ?`
+        )
+        .get(artifactId);
+      expect(tracker).toBeDefined();
+
+      const mappings = getMappings(db, tracker!.id);
+      expect(mappings).toHaveLength(0);
+    });
+  });
+});

--- a/action/src/spantracker/tracker.ts
+++ b/action/src/spantracker/tracker.ts
@@ -7,6 +7,28 @@
 import type { IterationDatabase } from '../db/database';
 import { computeLineDiff, lineDiffToSpanMapping } from '@codjiflo/diff-engine';
 
+/**
+ * Count lines in a string.
+ *
+ * Matches the helper in `packages/diff-engine/src/line-diff.ts` so that
+ * the added/deleted branches here agree with the semantics used by the
+ * rest of the diff pipeline:
+ *
+ *   - ""          → 0 lines
+ *   - "foo"       → 1 line
+ *   - "foo\n"     → 1 line (trailing newline is a terminator, not a line)
+ *   - "foo\nbar"  → 2 lines
+ *   - "foo\nbar\n"→ 2 lines
+ *
+ * `content.split('\n').length` is wrong for both edge cases: it returns
+ * 1 for "" (a phantom line) and 2 for "foo\n" (off by one).
+ */
+function countLines(text: string): number {
+  if (!text) return 0;
+  const newlines = (text.match(/\n/g) ?? []).length;
+  return text.endsWith('\n') ? newlines : newlines + 1;
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -58,13 +80,17 @@ function computeSingleTracker(
 
   if (leftContent === null) {
     // File added - all lines are "added"
-    const lines = (rightContent ?? '').split('\n');
+    const lineCount = countLines(rightContent ?? '');
+    if (lineCount === 0) {
+      // Empty added file: no lines to map.
+      return;
+    }
     db.insertSpanMapping(
       trackerId,
       null,
       null,
       1,
-      lines.length,
+      lineCount,
       'added'
     );
     return;
@@ -72,11 +98,15 @@ function computeSingleTracker(
 
   if (rightContent === null) {
     // File deleted - all lines are "deleted"
-    const lines = leftContent.split('\n');
+    const lineCount = countLines(leftContent);
+    if (lineCount === 0) {
+      // Previously-empty deleted file: no lines to map.
+      return;
+    }
     db.insertSpanMapping(
       trackerId,
       1,
-      lines.length,
+      lineCount,
       null,
       null,
       'deleted'


### PR DESCRIPTION
Closes #483

## Summary
- Replace `content.split('\n').length` in the added-file and deleted-file branches of `action/src/spantracker/tracker.ts` with a `countLines()` helper that matches the semantics used elsewhere in the diff pipeline (`packages/diff-engine/src/line-diff.ts`).
- Early-return without inserting a span mapping when the file has 0 lines, instead of fabricating a phantom `[1, 1]` range for empty content.

## Why
`'foo\n'.split('\n').length === 2` even though the file has 1 line, and `''.split('\n').length === 1` even though the file has 0 lines. Both branches produced span mappings that were one line too long (for trailing-newline content) or invented a line for empty files.

## Test plan
- First commit (`218fec5`) introduces 4 failing tests in `action/src/spantracker/tracker.test.ts` exercising both branches with trailing-newline and empty content; verified failing against the buggy implementation (e.g. `right_line_end` was 4 instead of 3, empty content inserted 1 mapping instead of 0).
- Second commit (`d2af5f6`) applies the fix; all 62 action tests pass and `npm run typecheck` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/490)**

<!-- codjiflo-link -->