### PR TITLE
fix: paginate artifact lookup for cross-run continuity

### DIFF
--- a/action/src/artifact/artifact-download.test.ts
+++ b/action/src/artifact/artifact-download.test.ts
@@ -17,6 +17,7 @@ import {
 } from './artifact-download';
 
 // Mock octokit
+const mockPaginateIterator = vi.fn();
 const mockOctokit = {
   rest: {
     actions: {
@@ -25,7 +26,23 @@ const mockOctokit = {
       getArtifact: vi.fn(),
     },
   },
+  paginate: {
+    iterator: mockPaginateIterator,
+  },
 };
+
+/**
+ * Helper to build an async iterator that yields the given pages.
+ */
+function buildAsyncIterator<T>(pages: T[][]): AsyncIterable<{ data: T[] }> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const page of pages) {
+        yield { data: page };
+      }
+    },
+  };
+}
 
 describe('findLatestArtifact', () => {
   beforeEach(() => {
@@ -295,6 +312,50 @@ describe('findNewestCodjifloArtifactForPR', () => {
     );
 
     expect(result?.id).toBe(99);
+  });
+
+  it('should find target artifact on page 2 when page 1 is dominated by unrelated artifacts', async () => {
+    // Page 1: 100 non-matching artifacts (other CI jobs on a busy repo)
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      id: 10000 + i,
+      name: `other-ci-artifact-${i}`,
+      created_at: '2025-01-10T10:00:00Z',
+      expired: false,
+      workflow_run: { id: 2000 + i },
+    }));
+    // Page 2: contains the target codjiflo artifact for PR 28
+    const page2 = [
+      {
+        id: 9000,
+        name: 'codjiflo-pr-28-1500',
+        created_at: '2025-01-05T10:00:00Z',
+        expired: false,
+        workflow_run: { id: 1500 },
+      },
+      {
+        id: 8999,
+        name: 'other-artifact',
+        created_at: '2025-01-04T10:00:00Z',
+        expired: false,
+        workflow_run: { id: 1499 },
+      },
+    ];
+
+    mockPaginateIterator.mockReturnValue(buildAsyncIterator([page1, page2]));
+
+    const result = await findNewestCodjifloArtifactForPR(
+      mockOctokit as never,
+      'owner',
+      'repo',
+      28
+    );
+
+    expect(result).toEqual({
+      id: 9000,
+      name: 'codjiflo-pr-28-1500',
+      created_at: '2025-01-05T10:00:00Z',
+      workflow_run_id: 1500,
+    });
   });
 
   it('should return null when no matching artifact exists for PR', async () => {

--- a/action/src/artifact/artifact-download.test.ts
+++ b/action/src/artifact/artifact-download.test.ts
@@ -267,16 +267,15 @@ describe('findNewestCodjifloArtifactForPR', () => {
   });
 
   it('should find artifact matching PR-specific pattern', async () => {
-    mockOctokit.rest.actions.listArtifactsForRepo.mockResolvedValue({
-      data: {
-        total_count: 3,
-        artifacts: [
+    mockPaginateIterator.mockReturnValue(
+      buildAsyncIterator([
+        [
           { id: 100, name: 'codjiflo-pr-28-1000', created_at: '2025-01-03T10:00:00Z', expired: false, workflow_run: { id: 1000 } },
           { id: 99, name: 'codjiflo-pr-28-999', created_at: '2025-01-02T10:00:00Z', expired: false, workflow_run: { id: 999 } },
           { id: 98, name: 'codjiflo-pr-27-998', created_at: '2025-01-01T10:00:00Z', expired: false, workflow_run: { id: 998 } },
         ],
-      },
-    });
+      ])
+    );
 
     const result = await findNewestCodjifloArtifactForPR(
       mockOctokit as never,
@@ -294,15 +293,14 @@ describe('findNewestCodjifloArtifactForPR', () => {
   });
 
   it('should skip expired artifacts', async () => {
-    mockOctokit.rest.actions.listArtifactsForRepo.mockResolvedValue({
-      data: {
-        total_count: 2,
-        artifacts: [
+    mockPaginateIterator.mockReturnValue(
+      buildAsyncIterator([
+        [
           { id: 100, name: 'codjiflo-pr-28-1000', created_at: '2025-01-03T10:00:00Z', expired: true, workflow_run: { id: 1000 } },
           { id: 99, name: 'codjiflo-pr-28-999', created_at: '2025-01-02T10:00:00Z', expired: false, workflow_run: { id: 999 } },
         ],
-      },
-    });
+      ])
+    );
 
     const result = await findNewestCodjifloArtifactForPR(
       mockOctokit as never,
@@ -359,14 +357,13 @@ describe('findNewestCodjifloArtifactForPR', () => {
   });
 
   it('should return null when no matching artifact exists for PR', async () => {
-    mockOctokit.rest.actions.listArtifactsForRepo.mockResolvedValue({
-      data: {
-        total_count: 1,
-        artifacts: [
+    mockPaginateIterator.mockReturnValue(
+      buildAsyncIterator([
+        [
           { id: 98, name: 'codjiflo-pr-27-998', created_at: '2025-01-01T10:00:00Z', expired: false, workflow_run: { id: 998 } },
         ],
-      },
-    });
+      ])
+    );
 
     const result = await findNewestCodjifloArtifactForPR(
       mockOctokit as never,
@@ -463,15 +460,14 @@ describe('downloadArtifactWithFallback', () => {
     const mockZipData = new ArrayBuffer(100);
     // First call for specific artifact ID fails
     mockOctokit.rest.actions.getArtifact.mockRejectedValue(new Error('Not found'));
-    // Fallback call lists all artifacts (PR-specific pattern)
-    mockOctokit.rest.actions.listArtifactsForRepo.mockResolvedValue({
-      data: {
-        total_count: 1,
-        artifacts: [
+    // Fallback call paginates over artifacts (PR-specific pattern)
+    mockPaginateIterator.mockReturnValue(
+      buildAsyncIterator([
+        [
           { id: 99, name: 'codjiflo-pr-28-998', created_at: '2025-01-01T10:00:00Z', expired: false, workflow_run: { id: 998 } },
         ],
-      },
-    });
+      ])
+    );
     mockOctokit.rest.actions.downloadArtifact.mockResolvedValue({
       data: mockZipData,
     });
@@ -489,14 +485,13 @@ describe('downloadArtifactWithFallback', () => {
 
   it('should try fallback when no specific ID is provided', async () => {
     const mockZipData = new ArrayBuffer(100);
-    mockOctokit.rest.actions.listArtifactsForRepo.mockResolvedValue({
-      data: {
-        total_count: 1,
-        artifacts: [
+    mockPaginateIterator.mockReturnValue(
+      buildAsyncIterator([
+        [
           { id: 100, name: 'codjiflo-pr-28-1000', created_at: '2025-01-03T10:00:00Z', expired: false, workflow_run: { id: 1000 } },
         ],
-      },
-    });
+      ])
+    );
     mockOctokit.rest.actions.downloadArtifact.mockResolvedValue({
       data: mockZipData,
     });
@@ -513,12 +508,7 @@ describe('downloadArtifactWithFallback', () => {
   });
 
   it('should return null when no artifacts exist at all', async () => {
-    mockOctokit.rest.actions.listArtifactsForRepo.mockResolvedValue({
-      data: {
-        total_count: 0,
-        artifacts: [],
-      },
-    });
+    mockPaginateIterator.mockReturnValue(buildAsyncIterator([[]]));
 
     const result = await downloadArtifactWithFallback(
       mockOctokit as never,

--- a/action/src/artifact/artifact-download.ts
+++ b/action/src/artifact/artifact-download.ts
@@ -161,8 +161,33 @@ export async function downloadArtifactById(
 }
 
 /**
+ * Maximum pages to scan when searching for a PR's newest codjiflo artifact.
+ * With per_page: 100, this covers up to 1000 most recent artifacts.
+ * GitHub retention is 90 days, so this is more than sufficient for active PRs
+ * while bounding the API cost on extremely busy repos.
+ */
+const FIND_ARTIFACT_MAX_PAGES = 10;
+
+/**
+ * Shape of a single artifact as returned by the GitHub REST API.
+ * Defined locally to avoid importing the full Octokit types surface.
+ */
+interface RepoArtifact {
+  id: number;
+  name: string;
+  created_at?: string | null;
+  expired?: boolean;
+  workflow_run?: { id?: number } | null;
+}
+
+/**
  * Find the newest codjiflo artifact for a specific PR.
  * Used as fallback when the specific artifact ID is not valid.
+ *
+ * Paginates through results because on busy repos the newest page(s) may be
+ * dominated by unrelated CI artifacts, pushing the target PR artifact to later
+ * pages. Without pagination we would silently return null and iteration
+ * continuity would reset (see issue #485).
  */
 export async function findNewestCodjifloArtifactForPR(
   octokit: ReturnType<typeof github.getOctokit>,
@@ -170,29 +195,42 @@ export async function findNewestCodjifloArtifactForPR(
   repo: string,
   prNumber: number
 ): Promise<ArtifactInfo | null> {
-  // List all artifacts matching codjiflo pattern for this PR
-  const { data } = await octokit.rest.actions.listArtifactsForRepo({
-    owner,
-    repo,
-    per_page: 100,
-  });
-
   // Pattern: codjiflo-pr-{prNumber}-{runId}
   const prPattern = new RegExp(`^codjiflo-pr-${prNumber}-\\d+$`);
 
-  // Find the first matching, non-expired artifact (list is sorted by created_at desc)
-  for (const artifact of data.artifacts) {
-    if (artifact.expired) {
-      continue;
+  const iterator = octokit.paginate.iterator(
+    octokit.rest.actions.listArtifactsForRepo,
+    {
+      owner,
+      repo,
+      per_page: 100,
     }
+  );
 
-    if (prPattern.test(artifact.name)) {
+  let pagesScanned = 0;
+  for await (const response of iterator) {
+    pagesScanned += 1;
+    const artifacts = (response.data ?? []) as RepoArtifact[];
+
+    // Artifacts are sorted by created_at desc within each page, so the first
+    // non-expired match is the newest.
+    for (const artifact of artifacts) {
+      if (artifact.expired) {
+        continue;
+      }
+      if (!prPattern.test(artifact.name)) {
+        continue;
+      }
       return {
         id: artifact.id,
         name: artifact.name,
         created_at: artifact.created_at ?? '',
         workflow_run_id: artifact.workflow_run?.id ?? 0,
       };
+    }
+
+    if (pagesScanned >= FIND_ARTIFACT_MAX_PAGES) {
+      break;
     }
   }
 


### PR DESCRIPTION
Closes #485

## Summary
- `findNewestCodjifloArtifactForPR` used `listArtifactsForRepo` with `per_page: 100` and no pagination. On busy repos the newest 100 artifacts can be dominated by unrelated CI artifacts, pushing the target `codjiflo-pr-{N}-{runId}` artifact to page 2+ where it was silently missed.
- This is the recovery path used when the specific artifact ID from the PR comment has expired (90-day retention), so the silent null caused iteration continuity to reset without any signal.
- Switch to `octokit.paginate.iterator` with early exit on first non-expired match and a `FIND_ARTIFACT_MAX_PAGES = 10` cap (covers 1000 most recent artifacts, bounding API cost on extreme repos while comfortably exceeding what a single PR accumulates in 90 days).

## Test plan
- [x] Added a failing test (prior commit) that mocks `paginate.iterator` with 100 non-matching artifacts on page 1 and the target artifact on page 2; asserted the target is returned.
- [x] Verified the test fails on the old single-page implementation.
- [x] Verified the test passes after the fix without regressing the existing 18 tests.
- [x] `npx tsc --noEmit` clean.
- [x] Full action suite (`npm test`) green: 59/59.

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.net/vezzadev/codjiflo/491)**

<!-- codjiflo-link -->