### PR TITLE
experiment: remove @swc/helpers override (test upstream fix from vercel/next.js#93852)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,14 +2,6 @@ import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  // Vercel platform regression (started 2026-05-13): lambda bundler omits
-  // @swc/helpers/esm/* from serverless trace, producing runtime
-  // `Cannot find module '/var/task/node_modules/@swc/helpers/esm/...'`.
-  // Confirmed still broken on next@16.2.6 + @swc/helpers@0.5.21 (2026-05-20).
-  // Tracked: vercel/next.js#93852 and Vercel Community thread 41956.
-  outputFileTracingIncludes: {
-    '/**/*': ['./node_modules/@swc/helpers/**'],
-  },
   images: {
     remotePatterns: [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "@codemirror/search": "^6.6.0",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.41.0",
-        "@swc/helpers": "^0.5.21",
         "@uiw/react-codemirror": "^4.25.9",
         "codemirror": "^6.0.2",
         "diff-match-patch": "^1.0.5",
@@ -3645,15 +3644,6 @@
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
@@ -10929,6 +10919,15 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "@codemirror/search": "^6.6.0",
     "@codemirror/state": "^6.5.4",
     "@codemirror/view": "^6.41.0",
-    "@swc/helpers": "^0.5.21",
     "@uiw/react-codemirror": "^4.25.9",
     "codemirror": "^6.0.2",
     "diff-match-patch": "^1.0.5",
@@ -62,7 +61,6 @@
     "zustand": "^5.0.10"
   },
   "overrides": {
-    "@swc/helpers": "^0.5.21",
     "esbuild": "^0.25.0",
     "path-to-regexp": "^8.0.0",
     "@playwright/test": "npm:@pedropaulovc/playwright-test@1.59.0-next.8",


### PR DESCRIPTION
## Summary
Tests whether removing `@swc/helpers` from `package.json` overrides (per Vercel maintainer guidance on https://github.com/vercel/next.js/issues/93852) eliminates the lambda packaging bug at its source, allowing us to drop the `outputFileTracingIncludes` workaround added in #495.

## Changes
- Remove `@swc/helpers` from `dependencies` and `overrides` in `package.json`
- Remove `outputFileTracingIncludes` block from `next.config.ts`
- Lockfile updated (Next.js now uses its declared transitive `@swc/helpers@0.5.15`)

## Test plan
- [ ] CI passes (lint, typecheck, unit, e2e, e2e-prod, storybook, capture-iteration)
- [ ] Vercel preview deploys successfully
- [ ] `curl <preview-url>/api/health` returns 200 (not 500 with `MIDDLEWARE_INVOCATION_FAILED` / `Cannot find module .../@swc/helpers/esm/_interop_require_default.js`)

If the preview is healthy, this is the real fix and we can merge to replace the workaround. If 500s come back, close this PR — the workaround stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/499)**

<!-- codjiflo-link -->