### PR TITLE
docs(openspec): propose adopt-react-aria change

### DIFF
--- a/openspec/changes/adopt-react-aria/.openspec.yaml
+++ b/openspec/changes/adopt-react-aria/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-26

--- a/openspec/changes/adopt-react-aria/design.md
+++ b/openspec/changes/adopt-react-aria/design.md
@@ -1,0 +1,156 @@
+## Context
+
+CodjiFlo's UI primitives live in `src/components/` (`Button`, `Input`, `Textarea`, `FormField`, `Badge`, `Skeleton`) and are thin wrappers over native HTML with custom CSS classes (`btn`, `btn-colorful`, `textbox`, `form-group`). All higher-level interactive surfaces — `features/theme/components/ThemeModal`, `features/keyboard/components/ShortcutsModal`, `features/diff/components/FileList`, `features/diff/components/DiffToolbar`, `features/diff/components/search/{SearchPanel,GoToLinePanel}`, `features/auth/components/RateLimitBanner`, `features/pr/components/PRHeader` — bolt their own keyboard, focus, and ARIA handling on top of these primitives. Examples of the resulting duplication and gaps:
+
+- `ThemeModal` ships a manual `useEffect`-bound Escape listener, focuses `modalRef.current` once, has no focus trap, no return-focus, no scroll lock, and uses a `<div role="dialog">` rather than a real focus-trapped dialog.
+- `Button` takes a `label: string` prop and an `ariaLabel` prop and forwards them to a native `<button>`; it does not centralise focus-visible styling.
+- `FormField` reimplements the `htmlFor`/`aria-describedby`/`aria-invalid` plumbing that every accessibility library bundles for free, with no `aria-errormessage` semantics.
+- There is no `Tree`, `Popover`, `ToggleButton`, or `SearchField` primitive; consumers ship one-off DOM constructions that are not lint-checked.
+
+The user has chosen [React Aria](https://react-aria.adobe.com/) (Adobe) and explicitly directed: **use react-aria as much as possible; replace components rather than wrap them; small UI changes are acceptable as long as they are reviewed first; do not worry about back-compat.** That steering shapes every decision below.
+
+The project uses React 19, Next.js 15 App Router with Turbopack, TypeScript strict, custom CSS with CSS variables, no Tailwind, Vitest + RTL, Storybook, Playwright. The test suite is fast (E2E budget: 5s/test). All of these are compatible with `react-aria-components`, which is framework-agnostic, SSR-safe, tree-shakeable, and ships render-state data attributes (`data-pressed`, `data-hovered`, `data-focus-visible`, `data-disabled`, `data-invalid`, `data-selected`, `data-expanded`) that our CSS can target directly.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Use `react-aria-components` as the **default** component layer. Where react-aria-components already provides everything we need, re-export it directly from `src/components/`; only introduce a wrapper when CSS class hooks or domain-specific composition (e.g. our themed Modal/Dialog pair) demand it. Wrappers MUST be the minimum viable layer — they do not exist to preserve old prop shapes.
+- Adopt react-aria's idiomatic API at every call site: `onPress` instead of `onClick` (and remove the `onClick`-to-`onPress` bridge entirely), `children` instead of `label`, `isDisabled`/`isInvalid`/`isPressed` instead of bespoke booleans, `errorMessage`/`description` slots instead of `error: string`/`helperText: string` props.
+- Delete the current hand-rolled `Button`, `Input`, `Textarea`, `FormField` implementations and the focus/Escape effects in modals; replace, do not wrap.
+- Drive ALL interactive-state styling off react-aria render-state data attributes; remove `:hover`/`:active`/`:focus-visible`-only rules on migrated primitives.
+- Make any default visual delta react-aria introduces (focus ring approach, modal overlay animation, tree row indent style, SearchField clear-button placement) **explicit and reviewed** with the user before the milestone lands.
+- Make accessibility regressions detectable in CI: unit tests assert ARIA contracts and axe-core; Playwright keyboard-only specs catch focus traps and tree navigation.
+
+**Non-Goals**
+
+- **No back-compat shims.** No prop aliases (`label?: string` falling back to `children`). No deprecation comments. No `// kept for compat` notes. When a prop is renamed, every caller is updated in the same change.
+- Not introducing Tailwind, CSS-in-JS, or any new styling system. Custom CSS stays.
+- Not rewriting the diff viewer's CodeMirror integration — CodeMirror owns its own accessibility model.
+- Not a visual redesign. We preserve the look but accept the small deltas react-aria-components introduces by default (subject to the UI-delta review gate).
+- Not adopting the entire React Aria ecosystem (DateField, ColorPicker, NumberField, …) — primitives are added only where we already have a usage today or within this change.
+- Not preserving the existing primitive prop contract. Existing callers will be updated.
+
+## Decisions
+
+### Decision 1: Use `react-aria-components` directly; wrappers are the exception
+
+**Choice:** `react-aria-components` is the default. For each primitive, decide explicitly:
+
+| Primitive | Decision |
+|---|---|
+| `Button` | **Wrap** — apply `btn`, `btn-colorful`, `btn-icon` classes. Variants (`primary`/`secondary`) and `size` (`default`/`sm`/`icon`) flow through className. Children, not `label`. `onPress`, not `onClick`. |
+| `ToggleButton` | **Re-export** from `react-aria-components`; CSS targets `[data-pressed]`. No wrapper. |
+| `TextField` (single-line) | **Re-export** the composition slot pattern (`TextField`, `Label`, `Input`, `Text`, `FieldError`) from `react-aria-components`; document the composition pattern in the architecture sidecar. Optionally provide a `<TextField>`-shaped helper if and only if it removes more code than it adds. |
+| `Textarea` | Same as single-line `TextField` but with `TextArea` slot. |
+| `Modal` + `Dialog` | **Wrap** — combine `Modal` + `ModalOverlay` + `Dialog` into a single themed `Modal` that applies `modal-overlay` and `modal` classes and handles the dismiss button slot. |
+| `Tree` | **Wrap** thinly to apply tree styling classes and the `Pull Request Description` pinned-top behavior. Default to `react-aria-components`'s `Tree`; fall back to `@react-aria/tree` + `@react-stately/tree` hooks only if the spike in task 1.3 proves the components API can't reuse `useFileTree`. |
+| `SearchField` | **Re-export** from `react-aria-components`; CSS targets `[data-empty]` to hide the clear control. |
+| `Popover` | **Re-export** from `react-aria-components`. |
+
+The bar for keeping a wrapper: it removes duplication every caller would otherwise write. The bar for adding one: same.
+
+**Why:** The user's explicit direction is to use react-aria as much as possible, replacing rather than wrapping. Wrappers exist only where they actually pay for themselves.
+
+**Alternatives considered:**
+- *Wrap everything* — was the previous design. Rejected: bakes in indirection forever for no benefit.
+- *Re-export everything with zero wrappers* — leaves themed Modal styling and Button class hooks duplicated at every call site. Rejected as too far the other way.
+
+### Decision 2: Adopt react-aria's idiomatic prop API; no back-compat
+
+**Choice:** Every call site changes in this PR. Prop renames:
+
+| Before | After |
+|---|---|
+| `<Button label="Save" onClick={fn} />` | `<Button onPress={fn}>Save</Button>` |
+| `<Button ariaLabel="Close" />` | `<Button aria-label="Close" />` (native attr, react-aria respects it) |
+| `<Button disabled />` | `<Button isDisabled />` |
+| `<Input label="Email" error="…" helperText="…" />` | `<TextField isInvalid={...}><Label>Email</Label><Input/><Text slot="description">…</Text><FieldError>…</FieldError></TextField>` |
+| `<Textarea label="…" error="…" />` | same composition with `TextArea` slot |
+| `<Modal isOpen onClose={fn}>` | `<Modal isOpen onOpenChange={fn}>` (react-aria signature) |
+
+No deprecation aliases. No JSDoc-marked "legacy" props. The full call-site sweep is part of this change. The task list pairs each primitive replacement with its caller migration so the working tree never has a half-migrated state.
+
+**Why:** Direct user steering: "dont worry about back-compat." Preserving prop shapes would add a wrapper layer that has to bridge `onClick→onPress`, `label→children`, etc. — exactly the indirection we are deleting.
+
+**Alternatives considered:**
+- *Keep the old shape via wrapper props* — rejected per the user's instruction.
+
+### Decision 3: Style react-aria components with our existing CSS via render-state data attributes
+
+**Choice:** Continue to apply our class names (`btn`, `btn-colorful`, `textbox`, `form-group`, `label`, `modal`, `modal-overlay`) on the react-aria components, but rewrite the interactive-state CSS in `src/styles/shared/buttons.css`, `src/styles/shared/controls.css`, and `src/styles/modals/modal-base.css` to target react-aria's data attributes:
+
+- `.btn:hover` → `.btn[data-hovered]`
+- `.btn:active` → `.btn[data-pressed]`
+- `.btn:focus-visible` → `.btn[data-focus-visible]`
+- `.btn:disabled` → `.btn[data-disabled]`
+- `.textbox:focus-visible` → `.textbox[data-focus-visible]`
+- `.textbox.textbox-error` (and the `textbox-error` class) → `.textbox[data-invalid]` (the `textbox-error` class is removed; react-aria's `isInvalid` flips the data attribute)
+
+CSS variables are unchanged. Pseudo-class-only rules on migrated primitives are deleted.
+
+**Why:** Data attributes capture states pseudo-classes cannot (e.g. `data-pressed` covers keyboard activation, `data-focus-visible` is library-managed and consistent). This is the canonical react-aria styling approach.
+
+### Decision 4: UI-delta review gate before each consumer milestone
+
+**Choice:** Before each milestone that ships react-aria components to production behavior, the agent MUST prepare a short side-by-side comparison (screenshot or DOM diff plus a description) of any visual or behavioral change react-aria introduces by default — focus ring shape and offset, modal overlay animation/easing, dialog dismiss button placement, tree row indent and chevron, SearchField clear control glyph and position, and any spacing change — and present it to the user via `AskUserQuestion` before the milestone commits. The user either approves the delta, requests a CSS tweak to preserve the current look, or rejects and the milestone is rescoped.
+
+This gate is encoded explicitly in `tasks.md` as a checkbox per milestone.
+
+**Why:** Direct user steering: "small ui changes may be acceptable as long as they are reviewed with the user first." We make that review a hard gate so deltas can't slip in silently.
+
+### Decision 5: Aggressive replacement, vertical-slice milestones
+
+**Choice:** Five milestones. Each is a self-contained vertical slice that BOTH adds the react-aria primitive AND removes the old one AND updates every caller AND passes the UI-delta review gate.
+
+1. **Dependencies + Modal/Dialog/ToggleButton/SearchField/Popover** — add the dependency; replace `ThemeModal` and `ShortcutsModal` with `Modal` + `Dialog`; introduce `ToggleButton` and `SearchField` as re-exports (no consumers yet — they ship together with the consumer migration in milestone 3).
+2. **Button + every Button caller** — delete the current `Button.tsx`; rewrite over `react-aria-components/Button` with `children`/`onPress`/`isDisabled`. Update every `<Button label={…} onClick={…} />` in `src/app/**` and `src/features/**` in the same PR.
+3. **TextField + Textarea + every text-input caller** — delete `Input.tsx`, `Textarea.tsx`, `FormField.tsx`. Update every caller to the `TextField`/`Label`/`Input`/`Text`/`FieldError` composition. `SearchPanel` and `GoToLinePanel` switch to `SearchField` / `TextField`. `DiffToolbar` toggles switch to `ToggleButton`.
+4. **Tree + FileList** — replace the file explorer's hand-rolled keyboard model with `Tree`/`TreeItem` (after the milestone-1 spike resolved the `useFileTree` integration approach).
+5. **Lint enforcement + sweep + axe coverage + Playwright keyboard E2E** — ship the ESLint rule banning native interactive elements outside `src/components/`, fix any remaining offenders in features/app, add unit-test axe assertions and the two keyboard E2E specs.
+
+**Why:** Each milestone is independently mergeable, the working tree never has a half-migrated state, and the UI-delta review gate fires per milestone rather than once at the end.
+
+### Decision 6: Enforce the primitive boundary with ESLint
+
+**Choice:** Add `eslint-rules/no-native-interactive-elements.js` (CommonJS, mirroring `eslint-rules/one-top-level-test-describe.js`) banning bare `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>` inside `src/features/**` and `src/app/**`. Allow them inside `src/components/**`, `**/*.test.tsx`, `**/*.stories.tsx`, and `src/tests/**`. The error message names the replacement (`Button` from `@/components`, `TextField` from `react-aria-components`, etc.).
+
+**Why:** Without enforcement, future code drifts back to native HTML and the migration's value erodes.
+
+### Decision 7: Accessibility verification stack
+
+**Choice:**
+- Unit-level: every primitive's Vitest + RTL test asserts core ARIA (`getByRole`, accessible name, render-state data attributes) and runs `@axe-core/react` on the rendered tree, failing on serious/critical violations.
+- Storybook: one story per render-state (default, hovered, pressed, focus-visible, disabled, invalid) so visual review can sanity-check; existing Storybook interaction tests verify keyboard activation.
+- End-to-end: Playwright specs `e2e/common/stateless-mode/keyboard-modal.spec.ts` (Tab cycle, Escape, return-focus on the Theme modal) and `keyboard-tree.spec.ts` (Up/Down/Left/Right/typeahead/Enter on the file explorer). Both budgeted under 5s.
+
+**Why:** Three complementary layers: unit catches contract regressions; Storybook catches visual regressions; Playwright catches integration regressions. Axe at the unit level is fast (no browser); skipping `@axe-core/playwright` keeps the E2E budget intact.
+
+## Risks / Trade-offs
+
+- **Risk:** Default react-aria visual differences (focus ring style, modal animation, tree indent) silently change the product look. → **Mitigation:** Decision 4's UI-delta review gate makes every default delta explicit; user signs off or asks for a CSS override before the milestone commits.
+- **Risk:** Replacing every call site in one milestone makes individual PRs large. → **Mitigation:** Each milestone replaces ONE primitive + its callers, not all primitives at once. Per-milestone PRs stay reviewable. CI runs `npm run test:all` per milestone so each is independently green.
+- **Risk:** `react-aria-components/Tree` may not interop cleanly with the existing `useFileTree` store. → **Mitigation:** Milestone-1 spike (task 1.3) resolves this before milestone 4 starts. Fallback: `@react-aria/tree` + `@react-stately/tree` hooks layered onto `useFileTree`. Outcome documented in `openspec/specs/ui-primitives/architecture.md` (the sidecar).
+- **Risk:** Bundle size grows. → **Mitigation:** `react-aria-components` is tree-shakeable; importing only Button/TextField/Modal/Dialog/Tree/Popover/ToggleButton/SearchField is on the order of 30 kB gzipped. Verify with `next build` + bundle analyzer at milestone 5; reject if the client growth exceeds 40 kB gzipped.
+- **Risk:** Lint rule false positives in test files. → **Mitigation:** Scope the rule to `src/features/**` and `src/app/**`, excluding `*.test.tsx`, `*.stories.tsx`, and `src/tests/**`.
+- **Risk:** SSR mismatch with portal-based `Modal`. → **Mitigation:** `react-aria-components` is SSR-safe (`useId`, `useLayoutEffect` shim, deferred portal). Smoke-test in milestone 1; check both `next dev` and `next build && next start`.
+- **Risk:** Storybook interaction tests break because the DOM tree shape changes. → **Mitigation:** Audit `Button.stories.test.tsx` and any other story test in the relevant milestone; replace exact-DOM assertions with `getByRole`/`getByLabelText` queries, which are also more resilient.
+- **Trade-off:** Updating every caller in the migration PR makes PRs larger than a behind-the-wrapper swap. We accept this because the user explicitly prioritised end-state cleanliness over migration size, and the per-milestone scope keeps individual PRs reviewable.
+
+## Migration Plan
+
+1. **Branch + dependency** — install `react-aria-components` and `@axe-core/react` (dev), commit lockfile, verify `npm run build` and `npm run test:all` baseline-green.
+2. **Milestone 1: Modal + Dialog + ToggleButton + SearchField + Popover** — wrap `Modal`/`Dialog` (themed), re-export the rest. Replace `ThemeModal` and `ShortcutsModal` callers in the same milestone; delete their Escape/focus `useEffect`s. UI-delta review gate. Add `keyboard-modal.spec.ts`.
+3. **Milestone 2: Button** — delete current `Button.tsx`; rewrite over `react-aria-components/Button`. Update every caller's prop shape (`label`→`children`, `onClick`→`onPress`, `disabled`→`isDisabled`, `ariaLabel`→`aria-label`). UI-delta review gate. Update `Button.test.tsx` and `Button.stories.test.tsx`.
+4. **Milestone 3: TextField + Textarea** — delete `Input.tsx`, `Textarea.tsx`, `FormField.tsx`. Update every caller to the composition pattern. Migrate `SearchPanel`/`GoToLinePanel` to `SearchField`/`TextField`; migrate `DiffToolbar` toggles to `ToggleButton`. UI-delta review gate.
+5. **Milestone 4: Tree + FileList** — pick the integration approach from the milestone-1 spike outcome. Replace `FileList`'s keyboard handling with `Tree`/`TreeItem`. UI-delta review gate. Add `keyboard-tree.spec.ts`.
+6. **Milestone 5: Lint enforcement + sweep + axe + bundle check** — land `eslint-rules/no-native-interactive-elements.js`, fix any remaining offenders (no `eslint-disable`), add `@axe-core/react` unit assertions per primitive, record bundle-size delta in the PR.
+7. **Spec promotion** — `/opsx:archive adopt-react-aria` lifts the deltas into `openspec/specs/ui-primitives/spec.md` (new) and updates `openspec/specs/ui-shell/spec.md`. Add an architecture sidecar `openspec/specs/ui-primitives/architecture.md` documenting which react-aria components we use, which we wrap and why, the data-attribute styling contract, and the Tree-integration decision from the spike.
+
+**Rollback strategy:** Each milestone is its own PR. If a milestone causes a regression, revert that single PR; earlier milestones remain. Because there is no back-compat wrapper layer, a revert restores the previous primitive implementation cleanly.
+
+## Open Questions
+
+- Does `react-aria-components/Tree` integrate with `useFileTree` directly, or do we adopt react-aria's `Collection` model and adapt `useFileTree` to it? Resolved by the milestone-1 spike (task 1.3) — outcome recorded in `openspec/specs/ui-primitives/architecture.md`.
+- The current `Button.size = "icon"` plus `ariaLabel` pattern: we replace with `<Button aria-label="…" className="btn-icon">…icon…</Button>`. Confirm during the milestone-2 UI-delta review whether to keep the `btn-icon` class or migrate to a dedicated `IconButton` re-export with the class baked in.
+- Should the new lint rule live alongside `one-top-level-test-describe.js` or be promoted to an `eslint-plugin-codjiflo` package? Default: keep it inline; revisit at three or more custom rules.

--- a/openspec/changes/adopt-react-aria/proposal.md
+++ b/openspec/changes/adopt-react-aria/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+CodjiFlo's interactive surfaces (buttons, inputs, modals, file explorer, search panels, theme picker) are hand-rolled atop native HTML with bespoke focus, keyboard, and ARIA wiring. As surfaces multiply (Theme modal, Shortcuts modal, Search panel, Go-to-line panel, file explorer tree, properties panel) the cost of keeping focus order, screen-reader semantics, and keyboard interactions correct grows non-linearly, and gaps already exist (no focus trap, no return-focus, ad-hoc Escape handling, no live regions on async errors). Adopting [React Aria](https://react-aria.adobe.com/) as the standard component layer lets us delete that surface area, gain WCAG 2.1 AA-grade behavior for free, and keep the custom CSS look-and-feel intact.
+
+The goal is to use `react-aria-components` **as much as possible** — replacing existing components rather than wrapping them, adopting react-aria's idiomatic props at every call site, and not preserving the current public API for back-compat. Small visual deltas (focus ring style, dialog overlay animation, default keyboard affordances) are acceptable but MUST be reviewed with a stakeholder before landing.
+
+## What Changes
+
+- Add `react-aria-components` as a direct dependency and use it as the **default** primitive layer; expose its components from `src/components/` either directly (re-exported) or behind a minimal wrapper that exists ONLY to apply our CSS class hooks.
+- Delete the current `src/components/Button/Button.tsx`, `src/components/Input/Input.tsx`, `src/components/Textarea/Textarea.tsx`, and `src/components/FormField/FormField.tsx` implementations. Replace with react-aria-components-based implementations using idiomatic props (`onPress` instead of `onClick`, `children` instead of `label`, react-aria's `validate` callback instead of an `error: string` prop where it improves the contract).
+- **BREAKING**: All call sites of `Button`, `Input`, `Textarea`, `FormField` are updated to the new props in the same change. No deprecation aliases. No `// kept for back-compat` shims.
+- Replace the hand-rolled `features/theme/components/ThemeModal` and `features/keyboard/components/ShortcutsModal` with `Modal` + `Dialog` from `react-aria-components` (focus trap, return-focus, scroll lock, Escape/overlay dismiss, portalled overlay) and delete their manual Escape/focus `useEffect`s.
+- Replace the file explorer tree (`features/diff/components/FileList`) with `Tree` / `TreeItem` from `react-aria-components`, refactoring `useFileTree` if necessary to feed react-aria's `Collection` model; do NOT keep a parallel hand-rolled tree.
+- Replace toggle controls in `features/diff/components/DiffToolbar` with `ToggleButton`; replace search inputs in `features/diff/components/search/SearchPanel` and `GoToLinePanel` with `SearchField` / `TextField` from react-aria-components.
+- Drive ALL component styling off react-aria's render-state data attributes (`[data-hovered]`, `[data-pressed]`, `[data-focus-visible]`, `[data-disabled]`, `[data-invalid]`, `[data-selected]`, `[data-expanded]`) — remove scattered `:hover` / `:active` / `:focus-visible` rules across `src/styles/`.
+- Add an ESLint rule banning bare `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>` outside `src/components/` so future code can't regress.
+- Update Storybook stories to demonstrate react-aria render-state variants and snapshot the rendered ARIA contract; add `@axe-core/react` assertions in unit tests for each replaced component.
+- Add Playwright keyboard-only specs for the Theme modal (focus trap + return-focus) and the file explorer tree (full keyboard model).
+
+This change **deletes** more code than it adds at the primitive layer. It does not introduce Tailwind, does not replace CSS variable theming, and does not aim for a visual redesign — but any visual delta react-aria introduces by default (e.g. its focus ring approach) is explicitly surfaced for approval in the design doc rather than papered over.
+
+## Capabilities
+
+### New Capabilities
+- `ui-primitives`: The contract for the application's accessible UI components — Button, TextField (single-line and multi-line), Modal/Dialog, Tree, SearchField, ToggleButton, Popover. Specifies keyboard interaction model, ARIA semantics, focus behavior, render-state data attributes that drive styling, and the rule that every interactive widget in the app is sourced from this layer (`react-aria-components`, optionally with a thin CSS wrapper) rather than hand-rolled.
+
+### Modified Capabilities
+- `ui-shell`: Restates the keyboard-navigation, focus, and theme-contrast requirements in terms of the `ui-primitives` contract (focus trap on modals, return-focus on dismiss, tree-grid keyboard model on the file explorer, visible focus indicator at AA contrast in every theme).
+
+## Impact
+
+- **Code (deleted)**: Current `src/components/Button/Button.tsx`, `src/components/Input/Input.tsx`, `src/components/Textarea/Textarea.tsx`, `src/components/FormField/FormField.tsx` — replaced wholesale. The manual focus and Escape `useEffect`s in `ThemeModal` and `ShortcutsModal`. Any hand-rolled "tree" walking in `features/diff/components/FileList`.
+- **Code (rewritten)**: `src/components/Button`, `Input`, `Textarea` re-implemented thinly over react-aria-components (or removed in favor of direct re-export). `src/components/ui/` gains `Modal`, `Dialog`, `Tree`, `Popover`, `ToggleButton`, `SearchField` modules. `src/features/theme/components/ThemeModal`, `src/features/keyboard/components/ShortcutsModal`, `src/features/diff/components/{FileList,DiffToolbar,search/SearchPanel,search/GoToLinePanel}`, plus every consumer of `Button` / `Input` / `Textarea` updated to the new (react-aria-idiomatic) prop shapes.
+- **Styling**: `src/styles/shared/{buttons,controls}.css`, `src/styles/modals/modal-base.css`, and any `:focus-visible`/`:hover`/`:active` rules in feature-scoped CSS rewritten to target react-aria render-state data attributes. CSS variables unchanged.
+- **Dependencies**: Adds `react-aria-components`. Adds `@axe-core/react` as a devDependency for primitive a11y tests. No other deps removed in this change.
+- **Tests**: Existing primitive unit tests (`Button.test.tsx`, `Input.test.tsx`, `Textarea.test.tsx`, `FormField.test.tsx`, `Button.stories.test.tsx`, modal tests) rewritten against the new props and react-aria-components DOM. New Playwright specs `e2e/common/stateless-mode/keyboard-modal.spec.ts` and `keyboard-tree.spec.ts`. Storybook stories updated to drive the new components.
+- **Lint**: New `eslint-rules/no-native-interactive-elements.js` enforced in `src/features/**` and `src/app/**`.
+- **UI delta review**: The design doc enumerates each visual/behavioral change react-aria introduces by default (e.g. focus ring approach, modal animation, tree expand-collapse animation, SearchField clear-button placement). These MUST be reviewed and approved before the corresponding milestone lands.
+- **No back-compat shims**: Prop renames (`label` → `children`, `onClick` → `onPress`, etc.) propagate to every call site in the same change.

--- a/openspec/changes/adopt-react-aria/specs/ui-primitives/spec.md
+++ b/openspec/changes/adopt-react-aria/specs/ui-primitives/spec.md
@@ -1,0 +1,142 @@
+## ADDED Requirements
+
+### Requirement: Primitive Component Layer
+The system SHALL source every user-facing interactive widget — buttons, text inputs, multi-line inputs, modals/dialogs, tree views, search fields, toggle buttons, and popovers — from `react-aria-components` (either re-exported directly from `src/components/` or behind a minimal CSS-only wrapper). Application code (pages, feature components, stories) MUST NOT render bare native `<button>`, `<input>`, `<textarea>`, `<select>`, or `<dialog>` elements outside of `src/components/`, and MUST NOT introduce a parallel hand-rolled primitive (e.g. a custom focus-trapping dialog or a custom keyboard-driven tree).
+
+#### Scenario: Feature code consumes the primitive layer
+- **WHEN** a feature component needs a clickable action (e.g. "Apply theme")
+- **THEN** it imports `Button` from the primitives barrel `@/components` and does not render a raw `<button>` element
+
+#### Scenario: Lint rejects native interactive elements
+- **WHEN** a developer writes `<button onClick={...}>` inside `src/features/` or `src/app/`
+- **THEN** lint fails with a rule pointing at the corresponding primitive component (and the same applies to `<input>`, `<textarea>`, `<select>`, `<dialog>`)
+
+### Requirement: Button Primitive
+The system SHALL provide a `Button` primitive that, in addition to its visual variants (`primary`, `secondary`) and sizes (`default`, `sm`, `icon`), exposes the accessibility contract of a native button while remaining keyboard-, pointer-, and touch-driven: it MUST be activatable with Enter and Space, MUST emit a focus-visible state distinguishable from hover, MUST forward `disabled` semantics to assistive technology, and MUST accept an explicit accessible name for icon-only variants.
+
+#### Scenario: Keyboard activation
+- **WHEN** the button has keyboard focus and the user presses Space or Enter
+- **THEN** the button's press handler fires exactly once, and the press is announced by the underlying primitive (no synthetic click bridge)
+
+#### Scenario: Icon-only button has an accessible name
+- **WHEN** a button is rendered in icon size with no visible label
+- **THEN** the rendered DOM exposes an accessible name (via `aria-label` or `aria-labelledby`) so screen readers can announce its purpose
+
+#### Scenario: Disabled state blocks interaction
+- **WHEN** `disabled` is true
+- **THEN** the button does not fire its press handler on click, Enter, or Space, and assistive technology announces it as disabled
+
+#### Scenario: Focus-visible state styles separately from hover
+- **WHEN** the button receives focus via keyboard
+- **THEN** it renders the focus-visible style; hovering with a pointer alone MUST NOT trigger the focus-visible style
+
+### Requirement: Text Field Primitive
+The system SHALL provide single-line and multi-line text field primitives built on `react-aria-components`'s `TextField` composition (`TextField` + `Label` + `Input`/`TextArea` + `Text` + `FieldError`), wiring label, description, and error into the field with a single shared identity. The primitive MUST expose validation state to assistive technology, announce errors via the polite live region react-aria provides, and present an idiomatic react-aria API (e.g. `isInvalid`, `errorMessage`, `description`, `validate`) rather than the previous bespoke `error: string` / `helperText: string` props.
+
+#### Scenario: Label is programmatically associated with the field
+- **WHEN** an `Input` or `Textarea` renders with a `label` prop
+- **THEN** clicking the label focuses the field, and the rendered DOM exposes the label as the field's accessible name (no `htmlFor`/`id` plumbing required at the call site)
+
+#### Scenario: Error is announced and described
+- **WHEN** an `Input` renders with a non-empty `error` prop
+- **THEN** the field's invalid state is exposed (`aria-invalid="true"`), the error text is referenced as the field's description (`aria-describedby`), and the error region is announced via a polite live region
+
+#### Scenario: Helper text is exposed when no error
+- **WHEN** the field renders with `helperText` and no `error`
+- **THEN** the helper text is referenced as the field's description and is NOT announced as an error
+
+### Requirement: Modal / Dialog Primitive
+The system SHALL provide a `Modal` + `Dialog` primitive pair that traps focus inside the dialog, restores focus to the trigger element on dismiss, locks background scroll while open, dismisses on Escape and on overlay click (when dismissible), exposes a labelled dialog role to assistive technology, and renders inside a portal so its stacking context is independent of its ancestor.
+
+#### Scenario: Focus is trapped while the dialog is open
+- **WHEN** a dialog is open and the user presses Tab repeatedly
+- **THEN** focus cycles through the dialog's focusable descendants and never escapes to elements behind the overlay
+
+#### Scenario: Focus is restored on dismiss
+- **WHEN** the user dismisses the dialog (Escape, close button, or overlay click)
+- **THEN** focus returns to the element that opened the dialog
+
+#### Scenario: Background scroll is locked
+- **WHEN** the dialog is open
+- **THEN** scrolling the page behind the overlay has no effect, and scrolling resumes after dismiss
+
+#### Scenario: Dialog has an accessible name
+- **WHEN** a dialog is rendered with a heading
+- **THEN** the dialog's accessible name reflects that heading (`aria-labelledby` to the heading element)
+
+### Requirement: Tree View Primitive
+The system SHALL provide a `Tree` primitive supporting hierarchical items with expand/collapse, single selection, the standard tree keyboard model (Up/Down to move, Left to collapse or move to parent, Right to expand or move to first child, Home/End to jump, typeahead to select by name), and accessible roles (`tree`, `treeitem`, `group`).
+
+#### Scenario: Arrow keys navigate the tree
+- **WHEN** a tree has focus and the user presses Down
+- **THEN** focus moves to the next visible node; Up moves it back; Right expands a collapsed parent or moves into the first child of an expanded parent; Left collapses an expanded parent or moves to the parent of a leaf
+
+#### Scenario: Typeahead jumps to a matching node
+- **WHEN** the user types a printable character while the tree has focus
+- **THEN** focus jumps to the next visible node whose label starts with that character (case-insensitive), and continuing to type extends the search prefix
+
+#### Scenario: Tree exposes tree semantics
+- **WHEN** the tree renders
+- **THEN** the root has role `tree`, each node has role `treeitem` with `aria-level`, `aria-expanded` (when it has children), and `aria-selected` reflecting selection state
+
+### Requirement: Search Field Primitive
+The system SHALL provide a `SearchField` primitive with an integrated clear control that appears while text is present and clears the value on activation, supports Escape to clear and blur, and exposes the search role to assistive technology.
+
+#### Scenario: Clear control resets the field
+- **WHEN** the search field contains text and the user clicks the clear control or presses Escape
+- **THEN** the field's value resets to empty, the clear control hides, and the consumer's `onChange` receives the empty value
+
+#### Scenario: Search role is exposed
+- **WHEN** the search field renders
+- **THEN** the input exposes `role="searchbox"` (or its equivalent native `type="search"` semantics) so assistive technology announces it as a search input
+
+### Requirement: Toggle Button Primitive
+The system SHALL provide a `ToggleButton` primitive that exposes a pressed state to assistive technology, toggles on Enter/Space, and renders distinct styles for pressed vs unpressed using the library's pressed-state data attribute.
+
+#### Scenario: Pressed state is exposed
+- **WHEN** a toggle button is in the pressed state
+- **THEN** its rendered DOM exposes `aria-pressed="true"` and the styling reflects the pressed state via the documented data attribute (`[data-pressed]`)
+
+### Requirement: Popover Primitive
+The system SHALL provide a `Popover` primitive anchored to a trigger element that positions itself with collision detection, dismisses on Escape and on outside click, restores focus to the trigger on dismiss, and exposes an accessible relationship between trigger and popover content.
+
+#### Scenario: Popover opens anchored to its trigger
+- **WHEN** a popover is opened by activating its trigger
+- **THEN** the popover renders positioned next to the trigger, flipping or shifting when the viewport would clip it
+
+#### Scenario: Outside click dismisses the popover
+- **WHEN** the popover is open and the user clicks outside it
+- **THEN** the popover closes and focus returns to the trigger
+
+### Requirement: Focus Indicator
+The system SHALL render a visible focus indicator on every focusable primitive whenever focus is reached via keyboard, using the library's focus-visible data attribute (`[data-focus-visible]`) targeted from CSS, and the indicator MUST meet WCAG 2.1 AA contrast against the surrounding surface in every theme (dark, light, black, high-contrast).
+
+#### Scenario: Tabbing reveals the indicator
+- **WHEN** the user moves focus with the Tab key
+- **THEN** the newly focused primitive renders the focus indicator and the previously focused primitive removes it
+
+#### Scenario: Mouse focus does not show the indicator
+- **WHEN** the user clicks a primitive with the mouse
+- **THEN** the primitive does not render the focus-visible indicator unless focus subsequently moves via keyboard
+
+### Requirement: Themed Component Styling
+The primitive layer SHALL preserve CodjiFlo's CSS-variable theming and visual design by applying the project's existing class hooks (`btn`, `btn-colorful`, `btn-icon`, `textbox`, `form-group`, `label`, `modal`, `modal-overlay`, etc.) to react-aria components, and by driving ALL interactive-state styling (hover, press, focus-visible, disabled, invalid, selected, expanded) off react-aria's render-state data attributes — never off CSS pseudo-classes like `:hover`, `:active`, or `:focus-visible` alone.
+
+#### Scenario: Project class hooks apply to react-aria components
+- **WHEN** a `Button` is rendered with the primary variant
+- **THEN** the rendered element carries the `btn-colorful` class so CSS in `src/styles/shared/buttons.css` continues to style it without any visual regression
+
+#### Scenario: State data attributes drive interactive styling
+- **WHEN** a `Button`, `Input`, or `TreeItem` is in the hovered, pressed, focus-visible, disabled, invalid, selected, or expanded state
+- **THEN** the rendered element exposes the corresponding `data-*` attribute, and the project's CSS targets that attribute exclusively to render the state (no `:hover`/`:active`/`:focus-visible`-only rules remain on these primitives)
+
+### Requirement: Accessibility Test Coverage
+The system SHALL include automated accessibility checks for the primitive layer: every primitive's unit tests MUST assert its core ARIA contract (role, accessible name, state attributes), AND keyboard-only end-to-end tests MUST cover modal focus trapping, tree navigation, and toggle button activation.
+
+#### Scenario: Primitive unit test asserts ARIA contract
+- **WHEN** the `Button` primitive's test suite runs
+- **THEN** it asserts the rendered element has `role="button"`, an accessible name, and that `disabled` propagates to `aria-disabled` (or the native disabled state) — failing a primitive change that drops these would fail the build
+
+#### Scenario: Keyboard-only end-to-end test covers a modal
+- **WHEN** the Playwright suite opens the theme modal using keyboard activation alone
+- **THEN** Tab cycles inside the modal, Escape closes it, and focus returns to the trigger button — verified without any mouse interaction

--- a/openspec/changes/adopt-react-aria/specs/ui-primitives/spec.md
+++ b/openspec/changes/adopt-react-aria/specs/ui-primitives/spec.md
@@ -12,7 +12,7 @@ The system SHALL source every user-facing interactive widget — buttons, text i
 - **THEN** lint fails with a rule pointing at the corresponding primitive component (and the same applies to `<input>`, `<textarea>`, `<select>`, `<dialog>`)
 
 ### Requirement: Button Primitive
-The system SHALL provide a `Button` primitive that, in addition to its visual variants (`primary`, `secondary`) and sizes (`default`, `sm`, `icon`), exposes the accessibility contract of a native button while remaining keyboard-, pointer-, and touch-driven: it MUST be activatable with Enter and Space, MUST emit a focus-visible state distinguishable from hover, MUST forward `disabled` semantics to assistive technology, and MUST accept an explicit accessible name for icon-only variants.
+The system SHALL provide a `Button` primitive that, in addition to its visual variants (`primary`, `secondary`) and sizes (`default`, `sm`, `icon`), exposes the accessibility contract of a native button while remaining keyboard-, pointer-, and touch-driven: it MUST be activatable with Enter and Space, MUST emit a focus-visible state distinguishable from hover, MUST forward the `isDisabled` prop to assistive technology, and MUST accept an explicit accessible name for icon-only variants.
 
 #### Scenario: Keyboard activation
 - **WHEN** the button has keyboard focus and the user presses Space or Enter
@@ -23,7 +23,7 @@ The system SHALL provide a `Button` primitive that, in addition to its visual va
 - **THEN** the rendered DOM exposes an accessible name (via `aria-label` or `aria-labelledby`) so screen readers can announce its purpose
 
 #### Scenario: Disabled state blocks interaction
-- **WHEN** `disabled` is true
+- **WHEN** `isDisabled` is true
 - **THEN** the button does not fire its press handler on click, Enter, or Space, and assistive technology announces it as disabled
 
 #### Scenario: Focus-visible state styles separately from hover
@@ -34,16 +34,16 @@ The system SHALL provide a `Button` primitive that, in addition to its visual va
 The system SHALL provide single-line and multi-line text field primitives built on `react-aria-components`'s `TextField` composition (`TextField` + `Label` + `Input`/`TextArea` + `Text` + `FieldError`), wiring label, description, and error into the field with a single shared identity. The primitive MUST expose validation state to assistive technology, announce errors via the polite live region react-aria provides, and present an idiomatic react-aria API (e.g. `isInvalid`, `errorMessage`, `description`, `validate`) rather than the previous bespoke `error: string` / `helperText: string` props.
 
 #### Scenario: Label is programmatically associated with the field
-- **WHEN** an `Input` or `Textarea` renders with a `label` prop
-- **THEN** clicking the label focuses the field, and the rendered DOM exposes the label as the field's accessible name (no `htmlFor`/`id` plumbing required at the call site)
+- **WHEN** a `TextField` renders with a child `Label` slot wrapping its `Input` (or `TextArea`) slot
+- **THEN** the composition wires the association without explicit `htmlFor`/`id` plumbing at the call site: clicking the rendered Label focuses the Input, and the rendered DOM exposes the Label text as the field's accessible name
 
 #### Scenario: Error is announced and described
-- **WHEN** an `Input` renders with a non-empty `error` prop
-- **THEN** the field's invalid state is exposed (`aria-invalid="true"`), the error text is referenced as the field's description (`aria-describedby`), and the error region is announced via a polite live region
+- **WHEN** a `TextField` is rendered with `isInvalid` and a child `FieldError` slot containing the error text
+- **THEN** the field's invalid state is exposed (`aria-invalid="true"` and `[data-invalid]`), the `FieldError` content is referenced as the field's description (`aria-describedby`), and the error region is announced via the polite live region react-aria provides
 
 #### Scenario: Helper text is exposed when no error
-- **WHEN** the field renders with `helperText` and no `error`
-- **THEN** the helper text is referenced as the field's description and is NOT announced as an error
+- **WHEN** a `TextField` is rendered with a child `<Text slot="description">` and is NOT in the invalid state
+- **THEN** the description text is referenced as the field's description (`aria-describedby` points at the `Text` slot) and is NOT announced as an error
 
 ### Requirement: Modal / Dialog Primitive
 The system SHALL provide a `Modal` + `Dialog` primitive pair that traps focus inside the dialog, restores focus to the trigger element on dismiss, locks background scroll while open, dismisses on Escape and on overlay click (when dismissible), exposes a labelled dialog role to assistive technology, and renders inside a portal so its stacking context is independent of its ancestor.
@@ -127,7 +127,7 @@ The primitive layer SHALL preserve CodjiFlo's CSS-variable theming and visual de
 - **THEN** the rendered element carries the `btn-colorful` class so CSS in `src/styles/shared/buttons.css` continues to style it without any visual regression
 
 #### Scenario: State data attributes drive interactive styling
-- **WHEN** a `Button`, `Input`, or `TreeItem` is in the hovered, pressed, focus-visible, disabled, invalid, selected, or expanded state
+- **WHEN** a `Button`, `TextField`, or `TreeItem` is in the hovered, pressed, focus-visible, disabled, invalid, selected, or expanded state
 - **THEN** the rendered element exposes the corresponding `data-*` attribute, and the project's CSS targets that attribute exclusively to render the state (no `:hover`/`:active`/`:focus-visible`-only rules remain on these primitives)
 
 ### Requirement: Accessibility Test Coverage
@@ -135,7 +135,7 @@ The system SHALL include automated accessibility checks for the primitive layer:
 
 #### Scenario: Primitive unit test asserts ARIA contract
 - **WHEN** the `Button` primitive's test suite runs
-- **THEN** it asserts the rendered element has `role="button"`, an accessible name, and that `disabled` propagates to `aria-disabled` (or the native disabled state) — failing a primitive change that drops these would fail the build
+- **THEN** it asserts the rendered element has `role="button"`, an accessible name, and that `isDisabled` propagates to `[data-disabled]` and the native disabled state — failing a primitive change that drops these would fail the build
 
 #### Scenario: Keyboard-only end-to-end test covers a modal
 - **WHEN** the Playwright suite opens the theme modal using keyboard activation alone

--- a/openspec/changes/adopt-react-aria/specs/ui-shell/spec.md
+++ b/openspec/changes/adopt-react-aria/specs/ui-shell/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: File Explorer Keyboard Navigation
+The system SHALL allow the user to navigate the file explorer entirely from the keyboard using the standard tree-view interaction model exposed by the `ui-primitives` `Tree` component: Up and Down move between visible nodes, Left collapses an expanded folder or moves to the parent of a leaf, Right expands a collapsed folder or moves into its first child, Home and End jump to the first and last visible nodes, printable-character typeahead jumps to the next node whose label starts with the typed prefix, Enter opens the selected file in the diff view, Space toggles the marked state, and Ctrl+C copies the path. The file explorer MUST expose tree semantics (`role="tree"`, `treeitem`, `aria-level`, `aria-expanded`, `aria-selected`) and MUST render a visible focus indicator that meets WCAG 2.1 AA contrast in every theme.
+
+#### Scenario: Arrow keys move selection
+- **WHEN** the file explorer has focus and the user presses Down
+- **THEN** the selection moves to the next visible node (respecting the active filter), and pressing Up moves it back
+
+#### Scenario: Left and Right collapse and expand folders
+- **WHEN** an expanded folder node is focused and the user presses Left
+- **THEN** the folder collapses; pressing Right on a collapsed folder expands it; pressing Right on an already-expanded folder moves focus to its first child; pressing Left on a leaf or already-collapsed folder moves focus to the parent
+
+#### Scenario: Typeahead jumps to a file
+- **WHEN** the file explorer has focus and the user types one or more printable characters
+- **THEN** selection jumps to the next visible node whose label starts with the accumulated prefix (case-insensitive), and the prefix resets after a brief pause
+
+#### Scenario: Enter opens the file
+- **WHEN** a file is selected in the explorer and the user presses Enter
+- **THEN** that file is opened in the main content area's diff view (see capability `diff-viewing`)
+
+#### Scenario: Tree exposes tree semantics to assistive technology
+- **WHEN** the file explorer renders
+- **THEN** its container has `role="tree"`, each node has `role="treeitem"` with correct `aria-level` and (for folders) `aria-expanded`, and the selected node carries `aria-selected="true"`
+
+### Requirement: Review Properties Keyboard Access
+The system SHALL allow the user to tab between properties and to activate a property's link or action button with Enter or Space, without needing the mouse. Each focusable property MUST render a visible focus indicator meeting WCAG 2.1 AA contrast in every theme, and any action button on a property MUST be implemented via the `ui-primitives` `Button` so the accessibility contract (keyboard activation, focus-visible state, accessible name) is identical to other buttons in the app.
+
+#### Scenario: Tab through properties
+- **WHEN** the properties panel has focus
+- **THEN** Tab moves focus from one property to the next, Shift+Tab moves it back, Enter activates the focused property's primary link, and Space activates the focused property's action button when present
+
+#### Scenario: Focus indicator is visible in every theme
+- **WHEN** a property receives keyboard focus while the active theme is dark, light, black, or high-contrast
+- **THEN** the property renders the standard focus indicator at WCAG 2.1 AA contrast against the panel background
+
+### Requirement: High-contrast theme for accessibility
+The system SHALL provide a high-contrast theme variant whose palette guarantees that interactive controls, focus rings, text, and error states meet WCAG 2.1 AA contrast against their surrounding surfaces. The focus indicator MUST be driven by the `ui-primitives` focus-visible data attribute (`[data-focus-visible]`) so every primitive component receives the same indicator consistently.
+
+#### Scenario: User picks the high-contrast theme
+- **WHEN** the user selects `high-contrast` from the theme picker
+- **THEN** the shell re-renders with the high-contrast palette without a reload, and a quick keyboard tab across the titlebar, file explorer, toolbar, and properties panel reveals a visible focus indicator on every primitive
+
+#### Scenario: Focus indicator contrast holds across themes
+- **WHEN** the focus indicator is rendered on a `Button`, `Input`, or `Tree` node in any of the four themes
+- **THEN** the indicator's contrast ratio against the immediately surrounding background is at least 3:1 (the WCAG 2.1 AA non-text minimum)

--- a/openspec/changes/adopt-react-aria/specs/ui-shell/spec.md
+++ b/openspec/changes/adopt-react-aria/specs/ui-shell/spec.md
@@ -31,7 +31,7 @@ The system SHALL allow the user to tab between properties and to activate a prop
 - **THEN** Tab moves focus from one property to the next, Shift+Tab moves it back, Enter activates the focused property's primary link, and Space activates the focused property's action button when present
 
 #### Scenario: Focus indicator is visible in every theme
-- **WHEN** a property receives keyboard focus while the active theme is dark, light, black, or high-contrast
+- **WHEN** a property receives keyboard focus while the active theme is `dark`, `light`, `black`, or `high-contrast`
 - **THEN** the property renders the standard focus indicator at WCAG 2.1 AA contrast against the panel background
 
 ### Requirement: High-contrast theme for accessibility
@@ -42,5 +42,5 @@ The system SHALL provide a high-contrast theme variant whose palette guarantees 
 - **THEN** the shell re-renders with the high-contrast palette without a reload, and a quick keyboard tab across the titlebar, file explorer, toolbar, and properties panel reveals a visible focus indicator on every primitive
 
 #### Scenario: Focus indicator contrast holds across themes
-- **WHEN** the focus indicator is rendered on a `Button`, `Input`, or `Tree` node in any of the four themes
+- **WHEN** the focus indicator is rendered on a `Button`, `TextField`, or `Tree` node in any of the four themes (`dark`, `light`, `black`, `high-contrast`)
 - **THEN** the indicator's contrast ratio against the immediately surrounding background is at least 3:1 (the WCAG 2.1 AA non-text minimum)

--- a/openspec/changes/adopt-react-aria/tasks.md
+++ b/openspec/changes/adopt-react-aria/tasks.md
@@ -1,0 +1,70 @@
+## 1. Dependency and scaffolding
+
+- [ ] 1.1 Add `react-aria-components` to `dependencies` and `@axe-core/react` to `devDependencies` in `package.json`, run `npm install`, commit lockfile
+- [ ] 1.2 Verify `npm run build` and `npm run test:all` are green with the dependency installed but unused (baseline)
+- [ ] 1.3 Spike: render `<Tree>` from `react-aria-components` over a fake `useFileTree`-shaped collection and confirm Up/Down/Left/Right + typeahead + expand/collapse + selection work; record the chosen integration approach (components API vs `@react-aria/tree` hooks) in `openspec/specs/ui-primitives/architecture.md`
+- [ ] 1.4 Wire the existing CSS variables to react-aria render-state data attributes by previewing one button in `src/styles/shared/buttons.css`: replace `:hover` with `[data-hovered]`, `:active` with `[data-pressed]`, `:focus-visible` with `[data-focus-visible]`, `:disabled` with `[data-disabled]`; smoke-test in Storybook with a throwaway `<RAButton>` to validate the styling approach before milestone 2 commits
+
+## 2. Milestone 1 — Modal, Dialog, ToggleButton, SearchField, Popover (+ replace ThemeModal & ShortcutsModal)
+
+- [ ] 2.1 Create `src/components/ui/Modal/` (`Modal.tsx`, `Modal.test.tsx`, `index.ts`) wrapping `ModalOverlay` + `Modal` + `Dialog` from `react-aria-components`; apply `modal-overlay` and `modal` classes; expose a `<Modal isOpen onOpenChange={…} title="…">` API; portal-mounted; dismiss button slot inside
+- [ ] 2.2 Re-export `ToggleButton`, `SearchField`, `Popover`, `OverlayArrow` from `react-aria-components` via `src/components/ui/index.ts` (no wrappers)
+- [ ] 2.3 Replace `src/features/theme/components/ThemeModal.tsx` to render `Modal` from 2.1; delete the local `useEffect` Escape listener, `modalRef.current?.focus()`, and any hand-rolled `role="dialog"` markup; switch from the `isOpen`/`onClose` prop pair to react-aria's `isOpen`/`onOpenChange` signature; update the test file accordingly
+- [ ] 2.4 Replace `src/features/keyboard/components/ShortcutsModal.tsx` and `ShortcutsModal.test.tsx` to use the new `Modal`; assert dialog accessible name, focus trap (Tab cycles inside), Escape closes, focus returns to trigger
+- [ ] 2.5 Update `src/styles/modals/modal-base.css` to target `[data-entering]`/`[data-exiting]` (react-aria animation hooks) and `[data-focus-visible]` on the dismiss button; delete any unused overlay-click handlers in feature CSS
+- [ ] 2.6 **UI-delta review gate**: capture before/after screenshots of both modals (open state, focus indicator on dismiss button, overlay animation in/out); call out any default react-aria visual delta (overlay opacity, dialog shadow, dismiss-button placement, focus ring) and present via `AskUserQuestion` — block on approval before committing the milestone
+- [ ] 2.7 Add `e2e/common/stateless-mode/keyboard-modal.spec.ts`: open Theme modal with Enter on the trigger, Tab cycles inside, Escape closes, focus returns; under 5s budget
+- [ ] 2.8 Run `npm run test:all`; commit milestone 1
+
+## 3. Milestone 2 — Button (delete + rewrite + every caller)
+
+- [ ] 3.1 Delete the body of `src/components/Button/Button.tsx`; rewrite using `Button` from `react-aria-components`. Public API: `<Button onPress={…} variant="primary"|"secondary" size="default"|"sm"|"icon" isDisabled aria-label="…">{children}</Button>`. Apply `btn`/`btn-colorful`/`btn-icon` classes off variant/size. No `label` prop. No `onClick` bridge.
+- [ ] 3.2 Update `src/styles/shared/buttons.css` to target `[data-hovered]`/`[data-pressed]`/`[data-focus-visible]`/`[data-disabled]` on `.btn` and `.btn-colorful`; remove `:hover`/`:active`/`:focus-visible` rules for those selectors
+- [ ] 3.3 Rewrite `src/components/Button/Button.test.tsx`: assert `role="button"`, accessible name, keyboard activation (Space and Enter both fire `onPress` exactly once), `isDisabled` propagates, `[data-pressed]` set during press, `aria-label` exposed; add `@axe-core/react` no-serious-violations assertion
+- [ ] 3.4 Update `src/components/Button/Button.stories.tsx` and `Button.stories.test.tsx`: one story per render-state (default, hovered, pressed, focus-visible, disabled), interaction test drives `userEvent.keyboard("{Enter}")` and asserts the press handler fires
+- [ ] 3.5 Sweep every `<Button …/>` in `src/app/**` and `src/features/**`: rename `label` → children, `onClick` → `onPress`, `disabled` → `isDisabled`, `ariaLabel` → `aria-label`. Use `grep -rE "<Button" src/ --include='*.tsx'` to enumerate; expected files include at least `src/features/auth/components/RateLimitBanner.tsx`, `src/features/pr/components/PRHeader.tsx`, `src/features/diff/components/DiffToolbar.tsx`, `src/features/theme/components/ThemeModal.tsx`, `src/features/keyboard/components/ShortcutsModal.tsx`, `src/app/login/page.tsx`, `src/app/dashboard/page.tsx`. Confirm `npm run lint` and `npm run typecheck` cover the rename.
+- [ ] 3.6 **UI-delta review gate**: capture before/after screenshots of representative buttons (primary, secondary, icon, disabled, focus-visible); flag the react-aria focus ring vs the previous `:focus-visible` style; present via `AskUserQuestion`; block on approval
+- [ ] 3.7 Run `npm run test:all`; commit milestone 2
+
+## 4. Milestone 3 — TextField + Textarea + every text-input caller + DiffToolbar/Search
+
+- [ ] 4.1 Delete `src/components/Input/Input.tsx`, `src/components/Textarea/Textarea.tsx`, `src/components/FormField/FormField.tsx` and their tests
+- [ ] 4.2 Decide and document in `openspec/specs/ui-primitives/architecture.md` whether to re-export the `TextField`/`Label`/`Input`/`Text`/`FieldError` composition slots from `react-aria-components` directly, or to introduce one thin helper that bundles them (the bar: the helper must remove duplication every caller would otherwise write). Default: direct re-export from `src/components/ui/index.ts`.
+- [ ] 4.3 Update `src/styles/shared/controls.css`: `:focus-visible` → `[data-focus-visible]` on `.textbox`/`.textarea`; introduce `.textbox[data-invalid]` styling and remove the legacy `.textbox-error` class. Delete `.form-group` declarations that duplicate react-aria's `TextField` defaults, keep what the design actually needs.
+- [ ] 4.4 Sweep every `<Input …/>` and `<Textarea …/>` call site: replace with the `<TextField isInvalid={…}><Label>…</Label><Input/><Text slot="description">…</Text><FieldError>…</FieldError></TextField>` composition (or the helper from 4.2 if introduced). Expected files include any login form, comment composer, search panel, go-to-line panel.
+- [ ] 4.5 Replace `src/features/diff/components/search/SearchPanel.tsx` to use `SearchField` from `react-aria-components`; remove any hand-rolled Escape-clears-and-blurs logic (react-aria's `SearchField` handles it natively)
+- [ ] 4.6 Replace `src/features/diff/components/search/GoToLinePanel.tsx` to use the `TextField` composition with `inputMode="numeric"`, `validate` callback for the line-number validation, and `FieldError` for the error slot
+- [ ] 4.7 Replace toggle controls in `src/features/diff/components/DiffToolbar.tsx` with `ToggleButton` from `react-aria-components`; assert `aria-pressed` reflects state; CSS targets `[data-pressed]`
+- [ ] 4.8 Update every test that referenced exact-DOM shape (`Input.test.tsx`, `Textarea.test.tsx`, `FormField.test.tsx` are deleted; tests in feature folders that grep for `.textbox-error` or `.form-group` are updated to assert `[data-invalid]` or `aria-invalid="true"` instead). Use `getByRole`/`getByLabelText` to keep tests resilient. Add `@axe-core/react` assertions to one canonical TextField test.
+- [ ] 4.9 **UI-delta review gate**: capture before/after screenshots of: a labelled text field, an invalid text field with error, a text field with helper text, the diff search input, the go-to-line input, a DiffToolbar toggle in both states. Flag any react-aria default deltas (clear-button glyph in SearchField, error text spacing, toggle pressed style). Present via `AskUserQuestion`; block on approval.
+- [ ] 4.10 Run `npm run test:all`; commit milestone 3
+
+## 5. Milestone 4 — Tree + FileList
+
+- [ ] 5.1 Confirm the integration approach chosen in 1.3 still holds against the current `useFileTree` store; if not, redo the spike on a branch and update `openspec/specs/ui-primitives/architecture.md`
+- [ ] 5.2 Create `src/components/ui/Tree/` (or extend it from milestone 1) — a thin wrapper that applies the file-explorer styling classes and supports the pinned `Pull Request Description` top node. Default backing: `Tree`/`TreeItem` from `react-aria-components`. Fallback: `@react-aria/tree` + `@react-stately/tree` hooks per 1.3.
+- [ ] 5.3 Replace the keyboard handling, expand/collapse state, and selection model in `src/features/diff/components/FileList.tsx` with the new `Tree`; delete all hand-rolled `onKeyDown` listeners on tree nodes
+- [ ] 5.4 Verify keyboard model end-to-end against the spec: Up/Down move, Left collapses or moves to parent, Right expands or moves to first child, Home/End jump, Enter opens file, Space toggles mark, Ctrl+C copies path, printable typeahead. Confirm `role="tree"`, `treeitem`, `aria-level`, `aria-expanded`, `aria-selected` are emitted by react-aria.
+- [ ] 5.5 Update `FileList`'s unit and integration tests to assert tree semantics and the full keyboard model via `getByRole("tree")` and `getByRole("treeitem")`; add an `@axe-core/react` no-serious-violations assertion
+- [ ] 5.6 **UI-delta review gate**: capture before/after screenshots of the file explorer (expanded folders, selected item with focus ring, partial-mark folder, filtered view); flag react-aria's default tree row indent, chevron, and focus indicator deltas; present via `AskUserQuestion`; block on approval
+- [ ] 5.7 Add `e2e/common/stateless-mode/keyboard-tree.spec.ts`: focus the tree, Down moves selection, Right expands a folder, Left collapses, typeahead jumps to a file, Enter opens it; under 5s budget
+- [ ] 5.8 Run `npm run test:all`; commit milestone 4
+
+## 6. Milestone 5 — Lint enforcement, sweep, axe coverage, bundle check
+
+- [ ] 6.1 Add `eslint-rules/no-native-interactive-elements.js` (CommonJS, mirroring the pattern of `eslint-rules/one-top-level-test-describe.js`) banning bare `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>` in `src/features/**` and `src/app/**`; allow them inside `src/components/**`, `**/*.test.tsx`, `**/*.stories.tsx`, and `src/tests/**`; the error message MUST name the replacement primitive
+- [ ] 6.2 Register the rule in `eslint.config.*` and run `npm run lint`; resolve any remaining offenders by migrating them to react-aria — NO `eslint-disable`
+- [ ] 6.3 Add a unit test for the lint rule under `eslint-rules/__tests__/no-native-interactive-elements.test.js` using `@eslint/rule-tester` covering pass and fail cases per disallowed element
+- [ ] 6.4 Audit `src/components/ui/Modal/Modal.test.tsx`, the new Tree/SearchField/ToggleButton tests, and the migrated `Button`/`TextField` tests to ensure each runs `@axe-core/react` and fails on serious/critical violations
+- [ ] 6.5 Run `next build` and analyze the bundle; record the gzipped client growth delta in the PR description; reject if it exceeds 40 kB
+- [ ] 6.6 Smoke-test SSR by running `next build && next start` and loading the dashboard + a PR page; verify no hydration warnings in the console (especially for `Modal` portals)
+- [ ] 6.7 Run `npm run test:all`; commit milestone 5
+
+## 7. Documentation, sidecars, and archive readiness
+
+- [ ] 7.1 Create `openspec/specs/ui-primitives/architecture.md` documenting: which `react-aria-components` we re-export directly, which we wrap and why, the data-attribute styling contract, the lint rule, the Tree integration decision from 1.3, the UI-delta deltas that were accepted (with screenshots if useful)
+- [ ] 7.2 Update or create `openspec/specs/ui-shell/architecture.md` for the new file-explorer tree model; cross-reference `ui-primitives/architecture.md`
+- [ ] 7.3 Update `AGENTS.md` section 1.1 and 4.7 to point at `ui-primitives` and the lint rule as the source of truth for "no native interactive elements"; remove or update the line that says "Avoid using raw `<button>`, `<input>`, or `<select>` tags. Use the standardized components in `src/components/`" to reflect that the standardized components ARE react-aria
+- [ ] 7.4 Run `npm run spec:validate` and `openspec validate adopt-react-aria --strict`; ensure both pass
+- [ ] 7.5 Run `npm run test:all` one final time before requesting review
+- [ ] 7.6 Open the PR with bundle-size delta, accessibility test evidence, and the approved UI-delta screenshots in the description; on merge run `/opsx:archive adopt-react-aria` to promote the spec deltas into `openspec/specs/`

--- a/openspec/changes/adopt-react-aria/tasks.md
+++ b/openspec/changes/adopt-react-aria/tasks.md
@@ -52,7 +52,7 @@
 
 ## 6. Milestone 5 — Lint enforcement, sweep, axe coverage, bundle check
 
-- [ ] 6.1 Add `eslint-rules/no-native-interactive-elements.js` (CommonJS, mirroring the pattern of `eslint-rules/one-top-level-test-describe.js`) banning bare `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>` in `src/features/**` and `src/app/**`; allow them inside `src/components/**`, `**/*.test.tsx`, `**/*.stories.tsx`, and `src/tests/**`; the error message MUST name the replacement primitive
+- [ ] 6.1 Add `eslint-rules/no-native-interactive-elements.js` (CommonJS, mirroring the pattern of `eslint-rules/one-top-level-test-describe.js`) banning bare `<button>`, `<input>`, `<textarea>`, `<select>`, `<dialog>` in `src/features/**`, `src/app/**`, and `**/*.stories.tsx` (stories MUST drive the primitive components, not raw HTML); allow them only inside `src/components/**`, `**/*.test.tsx`, and `src/tests/**`; the error message MUST name the replacement primitive
 - [ ] 6.2 Register the rule in `eslint.config.*` and run `npm run lint`; resolve any remaining offenders by migrating them to react-aria — NO `eslint-disable`
 - [ ] 6.3 Add a unit test for the lint rule under `eslint-rules/__tests__/no-native-interactive-elements.test.js` using `@eslint/rule-tester` covering pass and fail cases per disallowed element
 - [ ] 6.4 Audit `src/components/ui/Modal/Modal.test.tsx`, the new Tree/SearchField/ToggleButton tests, and the migrated `Button`/`TextField` tests to ensure each runs `@axe-core/react` and fails on serious/critical violations


### PR DESCRIPTION
## Summary
- Proposes an OpenSpec change to replace hand-rolled UI primitives with `react-aria-components` for better accessibility, per direct user steering ("use react-aria as much as possible; replace components if possible; small UI changes acceptable if reviewed; don't worry about back-compat").
- Adds a new `ui-primitives` capability spec (Button, TextField, Modal/Dialog, Tree, SearchField, ToggleButton, Popover — keyboard model, ARIA, focus, data-attribute styling) and a `ui-shell` delta tightening file-explorer keyboard navigation, properties-panel keyboard access, and high-contrast theme requirements.
- Aggressive replacement strategy: delete current `Button`/`Input`/`Textarea`/`FormField`, rewrite with idiomatic react-aria props (`onPress`/`children`/`isDisabled`), update every call site in the same milestone — no back-compat shims.
- Five vertical-slice milestones (Modal → Button → TextField → Tree → lint+axe), each with a hard **UI-delta review gate** that surfaces react-aria's default visual deltas via `AskUserQuestion` before committing.
- No code changes in this PR — proposal/design/specs/tasks only. Validated with `openspec validate adopt-react-aria --strict`.

## Test plan
- [ ] CI `openspec validate --all --strict` passes
- [ ] `npm run spec:validate` passes locally
- [ ] Reviewer reads `proposal.md` and confirms scope matches intent
- [ ] Reviewer skims `design.md` decisions 1 (when to wrap vs re-export), 2 (no back-compat), and 4 (UI-delta review gate) for alignment
- [ ] Reviewer skims `tasks.md` milestone breakdown and confirms each milestone is mergeable independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/514)**

<!-- codjiflo-link -->