### PR TITLE
chore: untrack scheduled_tasks.lock and gitignore .claude runtime files

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"44a3bafa-ca62-4004-bf3e-5ae7937dcd44","pid":511392,"procStart":"2782558","acquiredAt":1780287086831}

--- a/.gitignore
+++ b/.gitignore
@@ -164,4 +164,10 @@ demos/
 
 # Letta agent configuration
 .letta/
-.claude/CLAUDE.md
+
+# Claude Code: ignore local/runtime files (lock files, CLAUDE.md, settings.local.json),
+# but keep shared project config and workflow commands tracked
+.claude/*
+!.claude/settings.json
+!.claude/commands/
+!.claude/skills/


### PR DESCRIPTION
`scheduled_tasks.lock` is a runtime lock file (session id, pid, timestamps) that should never have been committed.

- Removes it from tracking (`git rm --cached`)
- Ignores all of `.claude/*` except the shared `settings.json`, `commands/`, and `skills/` (the OpenSpec workflow commands referenced in AGENTS.md stay tracked)
- `settings.local.json` and the local `.claude/CLAUDE.md` are now ignored too

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/pedropaulovc/codjiflo/526)**

<!-- codjiflo-link -->