### PR TITLE
chore(e2e): repoint prod tests from pedropaulovc to vezzadev

### DIFF
--- a/e2e/fixtures/mode.ts
+++ b/e2e/fixtures/mode.ts
@@ -59,20 +59,20 @@ export function getE2EGitHubToken(): string | undefined {
 export const prodModeConfig = {
   // CodjiFlo repository for prod mode tests
   testRepo: {
-    owner: "pedropaulovc",
+    owner: "vezzadev",
     repo: "codjiflo",
     // PR #1 exists and is open
     prNumber: 1,
   },
   // PR with multiple files for keyboard navigation testing
   keyboardNavPR: {
-    owner: "pedropaulovc",
+    owner: "vezzadev",
     repo: "codjiflo",
     prNumber: 6,
   },
   // Non-existent PR for 404 testing
   notFoundPR: {
-    owner: "pedropaulovc",
+    owner: "vezzadev",
     repo: "codjiflo",
     prNumber: 0,
   },

--- a/e2e/prod/stateful-mode/iteration-file-status.spec.ts
+++ b/e2e/prod/stateful-mode/iteration-file-status.spec.ts
@@ -6,7 +6,7 @@ test.describe("Iteration File Status", () => {
   // Uses real PR #11 in codjiflo-e2e-test-repo which has target-file.yml first modified in iteration 2
 
   // Prod mode configuration - uses real PR #11 in e2e test repo
-  const config = { owner: "pedropaulovc", repo: "codjiflo-e2e-test-repo", prNumber: 11 };
+  const config = { owner: "vezzadev", repo: "codjiflo-e2e-test-repo", prNumber: 11 };
 
   test.beforeEach(async ({ page }) => {
     await setupAuthState(page);

--- a/e2e/prod/stateful-mode/iteration-tabs-ui.spec.ts
+++ b/e2e/prod/stateful-mode/iteration-tabs-ui.spec.ts
@@ -4,7 +4,7 @@ import { setupAuthState } from "../../fixtures/github-mocks";
 test.describe("Iteration Tabs UI (Prod Mode)", () => {
   // These tests require real iteration artifacts from PR #11 in e2e test repo
   const iterationTestPR = {
-    owner: "pedropaulovc",
+    owner: "vezzadev",
     repo: "codjiflo-e2e-test-repo",
     prNumber: 11,
   };


### PR DESCRIPTION
The `codjiflo` and `codjiflo-e2e-test-repo` repos were migrated from the `pedropaulovc` org to `vezzadev`. Prod-mode E2E tests hit the real GitHub API, so the owner needs updating or they 404 against the old org.

- `e2e/fixtures/mode.ts` — `testRepo`/`keyboardNavPR`/`notFoundPR` → `vezzadev/codjiflo`
- `e2e/prod/stateful-mode/iteration-file-status.spec.ts` — `vezzadev/codjiflo-e2e-test-repo` PR #11
- `e2e/prod/stateful-mode/iteration-tabs-ui.spec.ts` — `vezzadev/codjiflo-e2e-test-repo` PR #11

Verified the referenced PRs (codjiflo #1, #6; e2e-test-repo #11) transferred with the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/vezzadev/codjiflo/528)**

<!-- codjiflo-link -->