### PR TITLE
docs(openspec): propose migrate-deploy-to-cloudflare

### DIFF
--- a/openspec/changes/migrate-deploy-to-cloudflare/.openspec.yaml
+++ b/openspec/changes/migrate-deploy-to-cloudflare/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-01

--- a/openspec/changes/migrate-deploy-to-cloudflare/design.md
+++ b/openspec/changes/migrate-deploy-to-cloudflare/design.md
@@ -1,0 +1,71 @@
+## Context
+
+CodjiFlo is a Next.js 15 (App Router) app hosted on Vercel. Vercel's GitHub App auto-deploys production (`codjiflo.vza.net`) on push to `main` and PR previews (`pr-{n}.codjiflo.vza.net`), posting GitHub deployment statuses that CI polls (`wait-for-vercel`, `wait-for-deployment`). Env vars live in Vercel and sync locally via `vercel env pull`. The health endpoint reports the deployed commit via `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`. Cross-subdomain auth hardcodes `KNOWN_BASE_DOMAIN = .vza.net`.
+
+A base Cloudflare Worker has already been created. We are migrating hosting to that Worker, moving to the apex domain `codjiflo.net`, and adopting Cloudflare's default Git release process. The app has server runtime needs (OAuth callback routes, `/api/health`), so it cannot be a static export.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Serve production and PR previews from the Cloudflare Worker, driven by Cloudflare's Git integration (Workers Builds).
+- Cut over the canonical domain to `codjiflo.net`.
+- Keep CI's deploy-gating + prod-mode E2E behavior (wait for deploy → run E2E against the deployed URL → verify commit via `/api/health`).
+- Remove all Vercel coupling (config, CLI dep, env pull, `NEXT_PUBLIC_VERCEL_*`).
+- Make a successful Cloudflare deployment a required check on `main`.
+
+**Non-Goals:**
+- Rewriting application behavior, auth flow logic, or the iteration/artifact pipeline.
+- Changing the GitHub Action (`codjiflo/action`) that captures iteration data.
+- Multi-region / edge-data architecture beyond what the Worker provides by default.
+- Secretless local real-auth login. Deleting `.env.local` means local real-auth dev needs the secret supplied off-band. A **future feature** will consider enabling **GitHub device-flow credentials** for local dev (client-id-only, no client secret on the developer's machine) — see the device-flow assessment; out of scope for this migration.
+
+## Decisions
+
+### Next.js on Workers via OpenNext Cloudflare adapter
+Use `@opennextjs/cloudflare` with a `wrangler` config (`wrangler.jsonc` + `open-next.config.ts`). The app uses App Router server routes, so the adapter (full Node-compatible server on Workers) is required.
+- *Alternatives*: `@cloudflare/next-on-pages` (Pages-oriented, weaker App Router/runtime coverage, and we want Workers per the pre-created Worker); static export (impossible — needs server routes). OpenNext is the current Cloudflare-recommended path for App Router on Workers.
+
+### Default Cloudflare Git release process (Workers Builds), not a custom deploy workflow
+Connect the repo in the Cloudflare dashboard so Cloudflare builds on push and manages production + non-production (preview) deployments, posting GitHub deployment statuses. This mirrors the prior Vercel GitHub-App model, so CI keeps gating on GitHub deployment statuses rather than calling `wrangler deploy` from Actions.
+- *Alternatives*: `wrangler deploy` from a GitHub Actions job (more moving parts, secrets/token management, must re-implement previews + status posting). The user explicitly asked for the default Cloudflare git release process.
+
+### Domain cutover to `codjiflo.net`
+Production = `https://codjiflo.net`. Replace `codjiflo.vza.net` in CI health checks, `E2E_BASE_URL`, auth `KNOWN_BASE_DOMAIN` (→ `.codjiflo.net`), GitHub App homepage + callback URLs, and `architecture.md`.
+- **PR previews are served under a custom `*.codjiflo.net` preview domain** (if Cloudflare supports mapping one for non-production deployments), so previews share the `.codjiflo.net` cookie domain and cross-subdomain auth keeps working. If a custom preview domain proves unavailable and previews fall back to `*.workers.dev`, the consequence is login-per-preview (cookies don't span domains) — acceptable but not preferred. Either way CI reads the preview URL from the GitHub deployment status `target_url`, so it stays scheme-agnostic.
+- The old domain gets a **301 redirect** `codjiflo.vza.net → codjiflo.net`. `vza.net` lives in a **different Cloudflare account**, so this redirect is configured there, not in the app's account — it requires switching/re-logging into that account (a manual, off-band step that needs the user to authorize the account change).
+
+### Commit SHA source for `/api/health`
+Replace `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` with `NEXT_PUBLIC_APP_COMMIT_SHA`, sourced from Cloudflare Workers Builds' default build-time variable **`WORKERS_CI_COMMIT_SHA`**. Caveat: Workers Builds build variables are **not** available at runtime, so the build command must inline it into the bundle — `NEXT_PUBLIC_APP_COMMIT_SHA=$WORKERS_CI_COMMIT_SHA <opennext build>` — and `route.ts` reads `process.env.NEXT_PUBLIC_APP_COMMIT_SHA` (Next inlines `NEXT_PUBLIC_*` at build, same mechanism Vercel used).
+
+### Secrets in Cloudflare Secret Store, never downloaded
+Cloudflare Secret Store does not allow secret values to leave the store. The **only** app runtime secret is `GITHUB_APP_CLIENT_SECRET`; the client id is not sensitive and is a plain Worker **variable**. So: create a Secret Store for `codjiflo`, upload `GITHUB_APP_CLIENT_SECRET` into it, and **bind** the store to the Worker — the Worker reads the secret at runtime via the binding. Once the secret is confirmed in the store, **delete the entire `.env.local`** (a Vercel artifact that holds the plaintext secret) so the secret no longer lives on disk. Remove `vercel env pull` and every secret-download path from `scripts/ensure-env.js`; it must not fetch secrets from any provider. When `.env.local` is missing locally, `ensure-env` only prints off-band setup guidance (keep the `CI` short-circuit). Non-secret config (client id, `NEXT_PUBLIC_*`, app URL) is set as plain Worker/build env vars. Update help text and `AGENTS.md`.
+
+The **E2E GitHub token is not an app secret** and is not bound to the Worker: the app never reads it — only Playwright does. CI already injects the built-in `github.token` as `GITHUB_TOKEN` for prod-mode E2E (`ci-cd-pr.yml`/`ci-cd-main.yml`); locally it's a developer PAT in `.env.local`. `CODJIFLO_E2E_GITHUB_TOKEN` (the Vercel-stored name) is currently unwired — code reads `GITHUB_TOKEN` — so the migration either drops it or maps it locally.
+- *Alternatives*: auto-pulling secrets into `.env.local` (rejected — Secret Store won't export, and it contradicts the required off-band handling).
+
+### `pedrovezzadev` (org admin) for the Cloudflare↔GitHub link
+The Cloudflare GitHub integration and the `main` branch-protection required check are configured using the `pedrovezzadev` org-admin account, which holds the org/repo-admin rights needed to connect Workers Builds and enable the required deployment check. This is a standing role, not a temporary grant: regular code commits continue to be authored by `pedropaulovc`; `pedrovezzadev` is used only for org-admin operations (Cloudflare connection, branch protection).
+
+## Risks / Trade-offs
+
+- **Preview hostname scheme differs from Vercel's `pr-{n}` pattern** → CI already reads `target_url` from the GitHub deployment status, so it stays scheme-agnostic; only auth's `KNOWN_BASE_DOMAIN` needs the new apex.
+- **Cross-subdomain cookie auth breaks if previews are not under `*.codjiflo.net`** → decision is to configure a custom preview domain under `codjiflo.net`; if Cloudflare can't map one and previews land on `*.workers.dev`, previews won't share the auth cookie domain → fall back to login-per-preview.
+- **OpenNext adapter incompatibility with current `next.config.ts` (webpack/turbopack WASM for SQL.js)** → validate the OpenNext build locally before cutover; SQL.js runs client-side, so server build should be unaffected, but verify.
+- **DNS/SSL cutover gap on `codjiflo.net`** → stage DNS + Worker route before flipping CI health URLs; verify `/api/health` on the new domain first.
+- **Required check wedges merges if misconfigured** → enable the required Cloudflare check only after a green deploy is observed on a test PR.
+- **Hard cutover removes Vercel** → keep the Vercel project paused (not deleted) until the Worker has served a few green main deploys, for fast rollback.
+
+## Migration Plan
+
+1. Land app/build config on a branch: add `@opennextjs/cloudflare` + `wrangler` config + `open-next.config.ts`; update `package.json` build/deploy scripts; verify `npm run build` (OpenNext) and a local `wrangler dev`/preview.
+2. In Cloudflare (via `pedrovezzadev`), connect the repo (Workers Builds), set production branch = `main`, configure env vars/secrets, and map `codjiflo.net` (DNS + route).
+3. Open a test PR → confirm a Cloudflare preview deploys and posts a GitHub deployment status with a working `/api/health`.
+4. Repoint code/config: health commit source, `KNOWN_BASE_DOMAIN` → `.codjiflo.net`, GitHub App homepage/callback URLs, `scripts/ensure-env.js`, `AGENTS.md`, auth `architecture.md`.
+5. Repoint CI: rename/retarget `wait-for-vercel`/`wait-for-deployment` to the Cloudflare deployment environment, switch health URLs + `E2E_BASE_URL` to `codjiflo.net`/preview URLs.
+6. Enforce deployment on GitHub: add the successful Cloudflare deployment status check as a **required status check** in the `main` branch-protection rule (via `pedrovezzadev`), so every PR targeting `main` is blocked from merge until its Cloudflare deployment reports success. Enable only after a green deploy is confirmed on a test PR (avoid wedging merges).
+7. Remove Vercel: delete `vercel.json`, `.vercel/`, the `vercel` devDep, and `NEXT_PUBLIC_VERCEL_*` references.
+8. **Rollback**: re-enable the paused Vercel project + GitHub App, revert CI/domain/env commits; DNS points back to Vercel.
+
+## Open Questions
+
+None outstanding.

--- a/openspec/changes/migrate-deploy-to-cloudflare/proposal.md
+++ b/openspec/changes/migrate-deploy-to-cloudflare/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+CodjiFlo's hosting, preview deployments, and environment variables are all coupled to Vercel today. We are moving production and preview hosting to a Cloudflare Worker (already scaffolded) to consolidate on Cloudflare, use its native Git release process, and serve the app from a new apex domain `codjiflo.net`. Vercel-specific glue (env pull, `NEXT_PUBLIC_VERCEL_*`, CI deployment-status polling tuned to Vercel) becomes dead weight once the Worker is live.
+
+## What Changes
+
+- **BREAKING** Production and PR-preview hosting move from Vercel to a Cloudflare Worker. The Vercel project, `vercel.json`, `.vercel/`, and the `vercel` CLI dependency are removed.
+- The canonical app domain changes from `codjiflo.vza.net` to **`codjiflo.net`**. PR previews move from `pr-{number}.codjiflo.vza.net` to Cloudflare's preview hostnames under `codjiflo.net` (custom preview domain) / the Worker's `*.workers.dev` alias.
+- Releases use the **default Cloudflare Git release process** (Workers Builds connected to the GitHub repo): push to `main` → production deploy; PR/branch push → preview deploy, with deployment status posted back to GitHub.
+- Next.js is built/served on Workers via the OpenNext Cloudflare adapter; a `wrangler` config and `@opennextjs/cloudflare` build step replace the Vercel build.
+- The only app runtime **secret**, `GITHUB_APP_CLIENT_SECRET`, lives in a **Cloudflare Secret Store** bound to the Worker and is never exported/downloaded; the client id is a plain Worker **variable**, not a secret. `vercel env pull` and all secret-download code are removed; `scripts/ensure-env.js` no longer fetches secrets from any provider. Once `GITHUB_APP_CLIENT_SECRET` is in the Secret Store, the local `.env.local` (a Vercel artifact holding the plaintext secret) is **deleted entirely**. The E2E GitHub token is a **test-time** credential, not a Worker secret: CI injects the built-in `github.token` as `GITHUB_TOKEN` — it does not go into the Secret Store.
+- CI: `wait-for-vercel` (PR) and `wait-for-deployment` (main) jobs are repointed to gate on the **Cloudflare deployment status** and the new domain's `/api/health`. The health endpoint's commit source moves off `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`.
+- Repo/deploy ownership: the Cloudflare GitHub integration and `main` branch-protection are configured using the **`pedrovezzadev`** org-admin account (regular commits stay on `pedropaulovc`), so the **successful Cloudflare deployment** can be added as a **required status check** on `main`.
+
+## Capabilities
+
+### New Capabilities
+- `deployment`: Hosting platform, Git-based release process, production + PR-preview deployments, CI deploy-gating, and build-time commit/version reporting for the app.
+
+### Modified Capabilities
+None at the requirement level. `authentication` has no requirement-level `spec.md` (only `architecture.md`); the base-domain / callback-URL / preview-hostname change from `*.codjiflo.vza.net` to `codjiflo.net` is a config + architecture-doc update captured in tasks, not a behavior-scenario change.
+
+## Impact
+
+- **Config/infra**: remove `vercel.json`, `.vercel/`; add `wrangler` config + `@opennextjs/cloudflare`; update `package.json` scripts (`build`, deploy) and remove `vercel` devDep.
+- **Code**: `src/app/api/health/route.ts` (commit SHA source), `scripts/ensure-env.js`, `scripts/dev.js` (env bootstrap), `src/features/auth/utils/cookies.ts` (`KNOWN_BASE_DOMAIN`).
+- **CI**: `.github/workflows/ci-cd-pr.yml`, `.github/workflows/ci-cd-main.yml` (deploy-wait jobs + health URLs + `E2E_BASE_URL`).
+- **Docs/specs**: `openspec/specs/authentication/architecture.md`, `AGENTS.md` (env setup), new `openspec/specs/deployment/`.
+- **External**: GitHub App OAuth callback URLs, DNS for `codjiflo.net`, Cloudflare Workers Builds connection (via `pedrovezzadev`), `main` branch-protection required check.

--- a/openspec/changes/migrate-deploy-to-cloudflare/specs/deployment/spec.md
+++ b/openspec/changes/migrate-deploy-to-cloudflare/specs/deployment/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Git-based production release
+
+The system SHALL deploy production from `main` using Cloudflare's default Git release process (Workers Builds connected to the GitHub repository). A push to `main` SHALL trigger a build of the Next.js app (OpenNext Cloudflare adapter) and deploy the resulting Worker to the production environment served at `https://codjiflo.net`.
+
+#### Scenario: Push to main deploys production
+
+- **WHEN** a commit is pushed to the `main` branch
+- **THEN** Cloudflare builds and deploys the Worker to production
+- **AND** `https://codjiflo.net` serves the built commit
+
+#### Scenario: Health endpoint reports the deployed commit
+
+- **WHEN** a client requests `https://codjiflo.net/api/health` after a deploy completes
+- **THEN** the response `commit` field equals the Git SHA that was built (sourced from the Cloudflare/Worker build commit, not `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA`)
+
+### Requirement: Pull-request preview deployments
+
+The system SHALL create an isolated preview deployment for each pull request via the Cloudflare Git integration, reachable at a stable per-PR preview URL, so reviewers can exercise the PR's build before merge.
+
+#### Scenario: Opening a PR produces a preview
+
+- **WHEN** a pull request is opened or updated against `main`
+- **THEN** Cloudflare builds and deploys a preview for the PR's head commit
+- **AND** a deployment status with the preview URL is posted to the PR's head commit on GitHub
+
+#### Scenario: Preview serves the PR's commit
+
+- **WHEN** the preview URL's `/api/health` is requested
+- **THEN** the `commit` field equals the PR head SHA
+
+#### Scenario: Preview shares the auth cookie domain
+
+- **WHEN** a preview is served under the custom `*.codjiflo.net` preview domain
+- **THEN** it shares the `.codjiflo.net` cookie domain so cross-subdomain auth works without a separate login
+
+### Requirement: CI gates on successful deployment
+
+CI SHALL wait for the Cloudflare deployment to reach a successful state before running prod-mode E2E tests, and SHALL fail fast if the deployment reports failure. The successful Cloudflare deployment SHALL be configured as a required status check on the `main` branch.
+
+#### Scenario: Prod E2E waits for the preview deploy
+
+- **WHEN** the PR CI workflow runs
+- **THEN** the prod-mode E2E job waits for the Cloudflare preview deployment status to be `success`
+- **AND** runs against the preview URL via `E2E_BASE_URL`
+
+#### Scenario: Failed deployment fails CI
+
+- **WHEN** the Cloudflare deployment reports a `failure` or `error` state
+- **THEN** the deploy-gating CI job exits non-zero
+
+#### Scenario: Deployment required on main
+
+- **WHEN** a PR is evaluated for merge into `main`
+- **THEN** branch protection requires the Cloudflare deployment check to be successful
+
+### Requirement: Runtime secrets via Cloudflare Secret Store
+
+The app's only runtime secret, `GITHUB_APP_CLIENT_SECRET`, SHALL be stored in a Cloudflare Secret Store bound to the Worker and read at runtime through that binding; its value SHALL NOT be exported from the store, downloaded by tooling, or written into client-side bundles. Non-secret config (the client id, `NEXT_PUBLIC_*`, app URL) SHALL be plain Worker/build variables, not Secret Store entries. Test-time credentials such as the E2E GitHub token are NOT app secrets and SHALL NOT be bound to the Worker (CI injects the built-in `github.token`; local runs use a developer PAT).
+
+#### Scenario: Worker reads the secret from the bound store
+
+- **WHEN** a server route needs `GITHUB_APP_CLIENT_SECRET`
+- **THEN** it reads the value from the bound Cloudflare Secret Store at runtime
+- **AND** the value is never emitted to the client bundle or a deployment log
+
+#### Scenario: Client id is a non-secret variable
+
+- **WHEN** the build or Worker needs the GitHub client id
+- **THEN** it reads it from a plain env var, not from the Secret Store
+
+### Requirement: No tooling downloads secrets
+
+Local development tooling SHALL NOT fetch secrets from any provider. `scripts/ensure-env.js` SHALL skip provisioning in CI, and when `.env.local` is absent locally it SHALL print off-band setup guidance rather than downloading secret values.
+
+#### Scenario: Missing local env prints guidance, downloads nothing
+
+- **WHEN** `npm run dev` runs locally without an existing `.env.local`
+- **THEN** the env bootstrap prints off-band setup guidance
+- **AND** it does not fetch secrets from Vercel, Cloudflare, or any provider
+
+#### Scenario: CI skips env bootstrap
+
+- **WHEN** the env bootstrap runs with `CI` set
+- **THEN** it exits without attempting any provisioning

--- a/openspec/changes/migrate-deploy-to-cloudflare/tasks.md
+++ b/openspec/changes/migrate-deploy-to-cloudflare/tasks.md
@@ -1,0 +1,46 @@
+## 1. Build & adapter setup
+
+- [ ] 1.1 Add `@opennextjs/cloudflare` and `wrangler` as dev dependencies; remove the `vercel` dev dependency
+- [ ] 1.2 Add `wrangler.jsonc` (Worker name, compatibility date/flags, assets/route config) and `open-next.config.ts`
+- [ ] 1.3 Update `package.json` scripts: `build` → OpenNext Cloudflare build; add `preview`/`deploy` (wrangler); keep `dev` on Next/Turbopack (no secret-pull script)
+- [ ] 1.4 Verify `next.config.ts` SQL.js/WASM config is compatible with the OpenNext build (server build only; SQL.js is client-side)
+- [ ] 1.5 Run the OpenNext build locally and smoke-test with `wrangler dev`/`preview` (load app + `/api/health`)
+
+## 2. Cloudflare Git release process & Secret Store (via `pedrovezzadev`)
+
+- [ ] 2.1 Sign in as `pedrovezzadev`; connect the GitHub repo in Cloudflare (Workers Builds), production branch = `main`
+- [ ] 2.2 Create a Cloudflare Secret Store named `codjiflo` and add its binding to the Worker (`wrangler.jsonc`) so the secret is available at runtime
+- [ ] 2.3 Upload `GITHUB_APP_CLIENT_SECRET` (from the current `.env.local`) into the `codjiflo` Secret Store off-band (value never leaves the store). This is the only app secret; the E2E token is test-time only and is NOT uploaded
+- [ ] 2.4 Once `GITHUB_APP_CLIENT_SECRET` is confirmed in the Secret Store, delete the entire `.env.local` so the plaintext secret no longer lives on disk
+- [ ] 2.5 Set non-secret config as plain Worker/build env vars: client id (`GITHUB_APP_CLIENT_ID`, `NEXT_PUBLIC_GITHUB_CLIENT_ID`), `NEXT_PUBLIC_APP_URL=https://codjiflo.net`
+- [ ] 2.6 Map `codjiflo.net` (DNS + Worker route + SSL) to the production Worker; configure a custom `*.codjiflo.net` preview domain for non-production deployments so previews keep the `.codjiflo.net` cookie domain (fall back to `*.workers.dev` = login-per-preview only if a custom preview domain isn't supported)
+- [ ] 2.7 Open a throwaway test PR; confirm a Cloudflare preview deploys, posts a GitHub deployment status with `target_url`, and serves `/api/health`
+
+## 3. Application & config repoint
+
+- [ ] 3.1 Replace `NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA` in `src/app/api/health/route.ts` with `NEXT_PUBLIC_APP_COMMIT_SHA`; inline it at build time via the build command `NEXT_PUBLIC_APP_COMMIT_SHA=$WORKERS_CI_COMMIT_SHA <opennext build>` (Workers Builds build vars aren't available at runtime). Read `GITHUB_APP_CLIENT_SECRET` from the Secret Store binding at runtime (client id stays a plain env var)
+- [ ] 3.2 Update `src/features/auth/utils/cookies.ts` `KNOWN_BASE_DOMAIN` from `.vza.net` to `.codjiflo.net`
+- [ ] 3.3 Remove `vercel env pull` and all secret-download code from `scripts/ensure-env.js`; it must not fetch secrets from any provider. When `.env.local` is missing, print off-band setup guidance only (keep `CI` short-circuit, update help text)
+- [ ] 3.4 Verify `scripts/dev.js` startup works without any secret download (off-band `.env.local`)
+- [ ] 3.5 Resolve the E2E token: CI injects the built-in `github.token` as `GITHUB_TOKEN` (no stored PAT); `CODJIFLO_E2E_GITHUB_TOKEN` in `.env.local` is unwired since code reads `GITHUB_TOKEN`. Decide: drop `CODJIFLO_E2E_GITHUB_TOKEN`, or wire it → `GITHUB_TOKEN` for local prod-E2E. Not a Worker/Secret Store concern
+- [ ] 3.6 Update GitHub App homepage + OAuth callback URLs to `https://codjiflo.net` (and previews under `*.codjiflo.net` if used)
+
+## 4. CI/CD repoint
+
+- [ ] 4.1 `ci-cd-pr.yml`: retarget `wait-for-vercel` to the Cloudflare deployment environment; rename appropriately; keep reading `target_url` for the preview URL
+- [ ] 4.2 `ci-cd-pr.yml`: point preview health-check + `E2E_BASE_URL` at the Cloudflare preview URL
+- [ ] 4.3 `ci-cd-main.yml`: retarget `wait-for-deployment` to the Cloudflare production deployment; switch health URL + stress-test `E2E_BASE_URL` to `https://codjiflo.net`
+- [ ] 4.4 Remove the "Preview deployments handled by Vercel GitHub App" comment and any Vercel-specific env references in workflows
+
+## 5. Required deployment check & cleanup
+
+- [ ] 5.1 Enforce on GitHub: add the successful Cloudflare deployment status check as a required status check in the `main` branch-protection rule (using the `pedrovezzadev` org-admin account) so PRs targeting `main` can't merge until their Cloudflare deployment succeeds. Enable only after a green deploy is confirmed on a test PR
+- [ ] 5.2 Delete `vercel.json` and `.vercel/`; remove remaining `NEXT_PUBLIC_VERCEL_*` references
+- [ ] 5.3 Pause (do not delete) the Vercel project + disconnect its GitHub App once main has had a green Cloudflare deploy
+- [ ] 5.4 Configure a 301 redirect `codjiflo.vza.net → codjiflo.net` in the Cloudflare account that owns `vza.net` (a different account — requires re-login/account switch; ask the user to authorize the change). Verify the redirect resolves and preserves path
+
+## 6. Docs & verification
+
+- [ ] 6.1 Update `openspec/specs/authentication/architecture.md` (domain, preview hostnames, env source, callback URLs) and `AGENTS.md` env-setup notes
+- [ ] 6.2 Run `npm run test:all` (lint, typecheck, spec:validate, coverage, e2e, storybook) green
+- [ ] 6.3 Confirm prod-mode E2E passes against the live Cloudflare deployment and `/api/health` reports the correct commit on `codjiflo.net`


### PR DESCRIPTION
## What

OpenSpec **proposal** (docs only — no code yet) to replace Vercel hosting with the already-created Cloudflare Worker.

- **Hosting**: Cloudflare default Git release process (Workers Builds) for production + PR previews; OpenNext adapter for Next.js.
- **Domain**: cut over to apex `codjiflo.net`; **301 redirect** `codjiflo.vza.net → codjiflo.net` (configured in the separate Cloudflare account that owns `vza.net`).
- **Secrets**: only `GITHUB_APP_CLIENT_SECRET` goes to a Cloudflare **Secret Store** bound to the Worker; client id is a plain variable; `.env.local` deleted after upload; all secret-download code removed. E2E token stays test-time (`github.token` in CI).
- **CI**: deploy-gating repointed from Vercel to the Cloudflare deployment status; successful deployment made a **required check** on `main`.
- **Health**: `/api/health` commit via `WORKERS_CI_COMMIT_SHA`, inlined as `NEXT_PUBLIC_APP_COMMIT_SHA` (build-time only).

## Artifacts

`proposal.md` · `design.md` · `specs/deployment/spec.md` · `tasks.md` — `npm run spec:validate` passes (11/11).

## Notes for review

- New capability: `deployment`. No requirement-level change to `authentication` (it has only `architecture.md`).
- Manual/off-band steps flagged in tasks: Secret Store upload, `.env.local` deletion, the cross-account 301 redirect (needs account re-login), and enabling the required check after a green test-PR deploy.

Implementation follows via `/opsx:apply migrate-deploy-to-cloudflare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.vza.net/vezzadev/codjiflo/529)**

<!-- codjiflo-link -->