### PR TITLE
feat: visual indicator for stateless-mode PRs

### DIFF
--- a/docs/plans/2026-06-04-stateless-mode-indicator-design.md
+++ b/docs/plans/2026-06-04-stateless-mode-indicator-design.md
@@ -1,0 +1,93 @@
+# Stateless-mode visual indicator — design
+
+**Date:** 2026-06-04
+
+## Problem
+
+A PR's iteration data loads in one of two modes (`useIterationStore.mode`):
+
+- **stateful** — a CodjiFlo GitHub Action artifact (SQLite iteration DB) is available; full
+  iteration + span tracking.
+- **stateless** — fallback via the GitHub Timeline API when no artifact is found; iteration
+  tracking is limited (no span tracking, etc.).
+
+Today nothing in the UI tells the reviewer they're in stateless mode or why, so limited
+behaviour looks like a bug. The store already records a `statelessReason`, but it is never
+surfaced.
+
+## Goal
+
+When a PR is in stateless mode, show a compact, accessible indicator next to the iteration
+tabs that explains why, and — when the cause is that the user is signed out — offers a
+sign-in action.
+
+## Design
+
+### 1. Store: typed reason enum
+
+`useIterationStore` currently holds `statelessReason: string | null` as free text. Per the
+project's enum-over-string guidance, change it to a discriminated value so the UI branches
+reliably instead of string-matching:
+
+```ts
+export type StatelessReason = 'unauthenticated' | 'no-artifact';
+// store state: statelessReason: StatelessReason | null
+```
+
+- `'unauthenticated'` — an artifact reference exists but the user is anonymous (data is
+  available once signed in). Actionable.
+- `'no-artifact'` — no artifact reference; the repo likely lacks the CodjiFlo Action.
+  Informational.
+
+Human-readable copy moves into the component. Store console logging keeps its own strings.
+Stateful loads continue to set `statelessReason: null`.
+
+### 2. Component: `StatelessModeIndicator`
+
+Location: `src/features/iterations/components/StatelessModeIndicator.tsx`. Reads `mode` and
+`statelessReason` from the store.
+
+| Condition | Render |
+|-----------|--------|
+| `mode === 'stateful'` | `null` (no clutter in the normal case) |
+| `statelessReason === 'no-artifact'` | neutral info pill `⚡ Stateless`; tooltip: "No CodjiFlo artifact found. This repo may not have the CodjiFlo GitHub Action installed. Iteration tracking is limited." |
+| `statelessReason === 'unauthenticated'` | warning pill `⚠ Sign in for full tracking`; `onPress` triggers the existing login flow; tooltip explains data is available once signed in |
+
+Built from existing primitives only:
+
+- `Button` (react-aria) as the focusable tooltip trigger.
+- `TooltipTrigger` / `Tooltip` (already re-exported from `@/components/ui`).
+- `lucide-react` icons (`Zap`, `LogIn`).
+- `aria-label` on the pill so the state is conveyed without relying on colour.
+
+The sign-in action wires to the same login initiation used by the login screen (exact
+hook/route confirmed during implementation).
+
+### 3. Placement & styling
+
+Rendered as a sibling immediately after `<IterationSelector />` inside
+`.diff-header-iterations` in `DiffView.tsx` — both the PR-description view and the sticky
+file-header instance. Being a sibling (not inside the selector) means it still shows when
+the selector renders nothing because there are zero iterations.
+
+New styles in `src/styles/shared/features.css`:
+`.stateless-indicator`, `.stateless-indicator--info`, `.stateless-indicator--action`,
+using existing theme CSS variables (warning / `--error-fg` tones for the action variant).
+
+## Testing
+
+Per AGENTS.md exit criteria (TDD: failing-test commit first, then implementation commit,
+failure noted in the message).
+
+- **Unit:** component renders `null` in stateful mode, info pill for `no-artifact`, action
+  pill for `unauthenticated`; sign-in `onPress` invokes login. Store test for the new enum
+  values being set on each path.
+- **Integration:** a mode transition is reflected in the rendered pill.
+- **E2E (mock):** a PR with no artifact → stateless pill visible with the correct text.
+
+## Out of scope / non-goals
+
+- No indicator in stateful mode.
+- No change to how mode itself is detected — only how the reason is typed and surfaced.
+- No backwards-compatibility shim for the old free-text `statelessReason` (no current
+  readers display it).

--- a/docs/plans/2026-06-04-stateless-mode-indicator.md
+++ b/docs/plans/2026-06-04-stateless-mode-indicator.md
@@ -1,0 +1,486 @@
+# Stateless-mode Visual Indicator Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Show a compact, accessible pill next to the iteration tabs whenever a PR's iteration data is in stateless mode, explaining why — with an actionable sign-in variant when the cause is an anonymous session.
+
+**Architecture:** Convert the store's free-text `statelessReason` into a typed `StatelessReason` enum (`'unauthenticated' | 'no-artifact'`), then add a `StatelessModeIndicator` component that reads `mode` + `statelessReason` from `useIterationStore` and renders nothing in stateful mode, an info pill for `no-artifact`, or a sign-in action pill for `unauthenticated`. It is placed as a sibling of `<IterationSelector />` inside `.diff-header-iterations` in `DiffView.tsx`.
+
+**Tech Stack:** React 19, TypeScript (strict), Zustand, react-aria-components (`Button`, `TooltipTrigger`, `Tooltip`), lucide-react, custom CSS, Vitest + RTL, Playwright.
+
+---
+
+## Ground-truth references (verified)
+
+- Store: `src/features/iterations/stores/useIterationStore.ts`
+  - Local `IterationState` interface at lines 65–95; `statelessReason: string | null` at line 87.
+  - `loadIterations` sets the reason at lines 150–161 (`reason` local var), then `set({... statelessReason: reason ...})` at lines 197 and 213. Stateful path sets `statelessReason: null` at line 290.
+  - `initialState` at lines 108–122 (`statelessReason: null`).
+  - `persist` `partialize` (line 413) persists ONLY `selectedRanges` — `mode`/`statelessReason` are not persisted. No persist change needed.
+- Canonical types: `src/features/iterations/types.ts` — `IterationMode` at line 175; `IterationState.statelessReason: string | null` at line 206. (Note: the store file keeps its own local copy of these types; BOTH must be updated.)
+- Login initiation hook: `src/features/auth/hooks/useOAuthFlow.ts` → `const { initiateOAuth } = useOAuthFlow()`; `initiateOAuth()` redirects to GitHub OAuth. Exported via `src/features/auth/hooks/index.ts`.
+- UI primitives: `Button`, `TooltipTrigger`, `Tooltip` are re-exported from `@/components/ui` (see `src/components/ui/index.ts`).
+- Placement: `src/features/diff/components/DiffView.tsx` renders `<IterationSelector />` inside `.diff-header-iterations` at lines 206–208 (description view) and 242–244 (sticky file header).
+- Component barrel: `src/features/iterations/components/index.ts` (currently exports only `IterationSelector`).
+- Store stateless test cases: `src/features/iterations/stores/useIterationStore.test.ts` lines 335+ (`mockFindArtifactReference.mockResolvedValue(null)` → `no-artifact`).
+- Styling home: `src/styles/shared/features.css`.
+
+---
+
+## Task 1: Add `StatelessReason` enum to types
+
+**Files:**
+- Modify: `src/features/iterations/types.ts:175-206`
+- Modify: `src/features/iterations/stores/useIterationStore.ts` (local type copy at line 63/87, import)
+
+**Step 1: Add the type in `types.ts`** — directly after `IterationMode` (line 175):
+
+```ts
+/** Iteration storage mode: stateful (artifact available) or stateless (GitHub API only) */
+export type IterationMode = 'stateful' | 'stateless';
+
+/**
+ * Why iteration data is in stateless mode.
+ * - 'unauthenticated': a CodjiFlo artifact exists but the user is signed out (data available once signed in)
+ * - 'no-artifact': no CodjiFlo artifact found (repo likely lacks the CodjiFlo GitHub Action)
+ */
+export type StatelessReason = 'unauthenticated' | 'no-artifact';
+```
+
+Then change line 206:
+
+```ts
+  /** Reason for stateless mode (null when stateful) */
+  statelessReason: StatelessReason | null;
+```
+
+**Step 2: Update the store's local type copy** in `useIterationStore.ts`.
+
+Add `StatelessReason` to the existing import from `../types` (the import block that already brings in iteration types), and change line 87:
+
+```ts
+  /** Reason for stateless mode (null when stateful) */
+  statelessReason: StatelessReason | null;
+```
+
+**Step 3: Run typecheck to verify it FAILS** (the `reason` strings assigned at lines 156/159 are now type errors):
+
+Run: `npm run typecheck`
+Expected: FAIL — `Type 'string' is not assignable to type 'StatelessReason | null'` in `loadIterations`.
+
+**Step 4: Set enum values in `loadIterations`** (lines 150–161). Replace the sentence assignments with enum values:
+
+```ts
+            const hasArtifactReference = earlyReference !== null;
+            const isAuthenticated = useAuthStore.getState().token !== null;
+
+            let reason: StatelessReason;
+            if (hasArtifactReference && !isAuthenticated) {
+              reason = 'unauthenticated';
+              console.info(`[CodjiFlo] Entering stateless mode: not authenticated for ${prKey}`);
+            } else {
+              reason = 'no-artifact';
+              console.info(`[CodjiFlo] Entering stateless mode: no artifact found for ${prKey}`);
+            }
+```
+
+(The two `set({ ... statelessReason: reason ... })` calls at lines ~197 and ~213 now carry the enum; the stateful `statelessReason: null` at line 290 is unchanged.)
+
+**Step 5: Run typecheck to verify it PASSES**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+**Step 6: Update store tests** in `useIterationStore.test.ts`. The existing stateless tests assert `mode === 'stateless'`; add reason assertions. In the `no-artifact` test (line 335, `mockFindArtifactReference.mockResolvedValue(null)`):
+
+```ts
+      expect(state.mode).toBe('stateless');
+      expect(state.statelessReason).toBe('no-artifact');
+```
+
+Add a NEW test for the unauthenticated path (artifact reference present, load returns null, no token):
+
+```ts
+    it('should set statelessReason to "unauthenticated" when artifact exists but user is signed out', async () => {
+      useAuthStore.setState({ token: null });
+      mockFindArtifactReference.mockResolvedValue({ /* a non-null ArtifactReference; reuse the shape used elsewhere in this file */ });
+      mockLoad.mockResolvedValue(null);
+      mockGithubClientFetch.mockResolvedValue({ base: { sha: 'base' } });
+      mockTimelineLoad.mockResolvedValue({ iterations: [], collapsedGroups: [] });
+
+      await useIterationStore.getState().loadIterations('owner', 'repo', 1);
+
+      const state = useIterationStore.getState();
+      expect(state.mode).toBe('stateless');
+      expect(state.statelessReason).toBe('unauthenticated');
+    });
+```
+
+> Implementer note: import/locate `useAuthStore` the same way the file already mocks auth (check the top of the test for an existing `useAuthStore` import/mock; reuse it). Use the same `ArtifactReference` object shape the stateful tests build.
+
+**Step 7: Run the store tests**
+
+Run: `npm run test -- useIterationStore`
+Expected: PASS (all, including the new case).
+
+**Step 8: Commit**
+
+```bash
+git add src/features/iterations/types.ts src/features/iterations/stores/useIterationStore.ts src/features/iterations/stores/useIterationStore.test.ts
+git commit -m "feat(iterations): type statelessReason as a StatelessReason enum"
+```
+
+---
+
+## Task 2: `StatelessModeIndicator` component (TDD)
+
+**Files:**
+- Create: `src/features/iterations/components/StatelessModeIndicator.tsx`
+- Test: `src/features/iterations/components/StatelessModeIndicator.test.tsx`
+- Modify: `src/features/iterations/components/index.ts`
+
+**Step 1: Write the failing test** in `StatelessModeIndicator.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StatelessModeIndicator } from './StatelessModeIndicator';
+import { useIterationStore } from '../stores';
+
+const mockInitiateOAuth = vi.fn();
+vi.mock('@/features/auth/hooks', () => ({
+  useOAuthFlow: () => ({ initiateOAuth: mockInitiateOAuth, isInitiating: false, error: null, clearError: vi.fn() }),
+}));
+
+function setMode(mode: 'stateful' | 'stateless', statelessReason: 'unauthenticated' | 'no-artifact' | null) {
+  useIterationStore.setState({ mode, statelessReason });
+}
+
+describe('StatelessModeIndicator', () => {
+  beforeEach(() => {
+    mockInitiateOAuth.mockClear();
+    useIterationStore.getState().reset();
+  });
+
+  it('renders nothing in stateful mode', () => {
+    setMode('stateful', null);
+    const { container } = render(<StatelessModeIndicator />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a neutral info pill when the repo has no artifact', () => {
+    setMode('stateless', 'no-artifact');
+    render(<StatelessModeIndicator />);
+    const pill = screen.getByTestId('stateless-indicator');
+    expect(pill).toHaveTextContent(/stateless/i);
+    expect(pill).toHaveClass('stateless-indicator--info');
+  });
+
+  it('renders a sign-in action pill when unauthenticated', () => {
+    setMode('stateless', 'unauthenticated');
+    render(<StatelessModeIndicator />);
+    const pill = screen.getByTestId('stateless-indicator');
+    expect(pill).toHaveTextContent(/sign in/i);
+    expect(pill).toHaveClass('stateless-indicator--action');
+  });
+
+  it('initiates OAuth when the sign-in pill is pressed', async () => {
+    setMode('stateless', 'unauthenticated');
+    render(<StatelessModeIndicator />);
+    await userEvent.click(screen.getByTestId('stateless-indicator'));
+    expect(mockInitiateOAuth).toHaveBeenCalledOnce();
+  });
+});
+```
+
+**Step 2: Run the test to verify it FAILS**
+
+Run: `npm run test -- StatelessModeIndicator`
+Expected: FAIL — cannot resolve `./StatelessModeIndicator`.
+
+**Step 3: Implement the component** in `StatelessModeIndicator.tsx`:
+
+```tsx
+import { Zap, LogIn } from 'lucide-react';
+import { Button, TooltipTrigger, Tooltip } from '@/components/ui';
+import { useOAuthFlow } from '@/features/auth/hooks';
+import { useIterationStore } from '../stores';
+
+const NO_ARTIFACT_TOOLTIP =
+  'No CodjiFlo artifact found. This repo may not have the CodjiFlo GitHub Action installed. Iteration tracking is limited.';
+const UNAUTHENTICATED_TOOLTIP =
+  'CodjiFlo data is available for this PR. Sign in to enable full iteration tracking.';
+
+export function StatelessModeIndicator() {
+  const mode = useIterationStore((s) => s.mode);
+  const statelessReason = useIterationStore((s) => s.statelessReason);
+  const { initiateOAuth } = useOAuthFlow();
+
+  if (mode === 'stateful') {
+    return null;
+  }
+
+  if (statelessReason === 'unauthenticated') {
+    return (
+      <TooltipTrigger>
+        <Button
+          className="stateless-indicator stateless-indicator--action"
+          data-testid="stateless-indicator"
+          onPress={() => { initiateOAuth(); }}
+          aria-label="Stateless mode — sign in to enable full iteration tracking"
+        >
+          <LogIn size={12} aria-hidden="true" />
+          <span>Sign in for full tracking</span>
+        </Button>
+        <Tooltip className="stateless-indicator-tooltip">{UNAUTHENTICATED_TOOLTIP}</Tooltip>
+      </TooltipTrigger>
+    );
+  }
+
+  // statelessReason === 'no-artifact' (and any future stateless reason): neutral info pill
+  return (
+    <TooltipTrigger>
+      <Button
+        className="stateless-indicator stateless-indicator--info"
+        data-testid="stateless-indicator"
+        aria-label="Stateless mode — iteration tracking is limited"
+      >
+        <Zap size={12} aria-hidden="true" />
+        <span>Stateless</span>
+      </Button>
+      <Tooltip className="stateless-indicator-tooltip">{NO_ARTIFACT_TOOLTIP}</Tooltip>
+    </TooltipTrigger>
+  );
+}
+```
+
+> Note: the info-variant `Button` has no `onPress` — it exists solely as a focusable tooltip trigger (react-aria requires a focusable trigger). That is acceptable; the `aria-label` carries the meaning.
+
+**Step 4: Run the test to verify it PASSES**
+
+Run: `npm run test -- StatelessModeIndicator`
+Expected: PASS (all 4 cases).
+
+**Step 5: Export from the barrel** — add to `src/features/iterations/components/index.ts`:
+
+```ts
+export { StatelessModeIndicator } from './StatelessModeIndicator';
+```
+
+Also confirm it is reachable via the feature barrel `src/features/iterations/index.ts` (it re-exports from `./components`; add there too if that file lists components individually).
+
+**Step 6: Commit**
+
+```bash
+git add src/features/iterations/components/StatelessModeIndicator.tsx src/features/iterations/components/StatelessModeIndicator.test.tsx src/features/iterations/components/index.ts src/features/iterations/index.ts
+git commit -m "feat(iterations): add StatelessModeIndicator component"
+```
+
+---
+
+## Task 3: Styles
+
+**Files:**
+- Modify: `src/styles/shared/features.css` (append)
+
+**Step 1: Add styles** using theme CSS variables (match the existing `.badge` look in `controls.css` for sizing):
+
+```css
+/* Stateless-mode indicator (next to iteration tabs) */
+.stateless-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.stateless-indicator--info {
+  background-color: var(--badge-merged);
+  color: white;
+}
+
+.stateless-indicator--action {
+  background-color: var(--error-fg);
+  color: white;
+  cursor: pointer;
+}
+
+.stateless-indicator--action[data-hovered],
+.stateless-indicator--action[data-focus-visible] {
+  filter: brightness(1.1);
+  outline: 2px solid var(--focus-border);
+  outline-offset: 1px;
+}
+
+.stateless-indicator-tooltip {
+  max-width: 260px;
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  background-color: var(--menu-hover);
+  color: var(--watermark-text);
+}
+```
+
+> Implementer note: confirm each `var(--...)` exists in `src/styles/themes/variables.css`. If `--menu-hover`/`--watermark-text` don't read well for a tooltip, pick the nearest existing tooltip/menu token rather than inventing a new variable.
+
+**Step 2: Verify it builds/lints**
+
+Run: `npm run lint`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add src/styles/shared/features.css
+git commit -m "feat(iterations): style stateless-mode indicator pill"
+```
+
+---
+
+## Task 4: Wire into DiffView
+
+**Files:**
+- Modify: `src/features/diff/components/DiffView.tsx` (import + lines 206–208 and 242–244)
+
+**Step 1: Import** alongside the existing `IterationSelector` import (line 35):
+
+```ts
+import { IterationSelector, StatelessModeIndicator } from '@/features/iterations';
+```
+
+**Step 2: Render as a sibling** in BOTH `.diff-header-iterations` blocks:
+
+```tsx
+        <div className="diff-header-iterations" data-testid="diff-header-iterations">
+          <IterationSelector />
+          <StatelessModeIndicator />
+        </div>
+```
+
+(Apply to both the description-view block ~line 206 and the sticky-header block ~line 242.)
+
+**Step 3: Typecheck + lint**
+
+Run: `npm run typecheck && npm run lint`
+Expected: PASS.
+
+**Step 4: Commit**
+
+```bash
+git add src/features/diff/components/DiffView.tsx
+git commit -m "feat(diff): show StatelessModeIndicator beside iteration tabs"
+```
+
+---
+
+## Task 5: Integration test
+
+**Files:**
+- Create: `src/features/iterations/components/StatelessModeIndicator.integration.test.tsx`
+
+**Step 1: Write the test** — a mode transition is reflected in the rendered pill:
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { StatelessModeIndicator } from './StatelessModeIndicator';
+import { useIterationStore } from '../stores';
+
+vi.mock('@/features/auth/hooks', () => ({
+  useOAuthFlow: () => ({ initiateOAuth: vi.fn(), isInitiating: false, error: null, clearError: vi.fn() }),
+}));
+
+describe('StatelessModeIndicator (integration)', () => {
+  beforeEach(() => { useIterationStore.getState().reset(); });
+
+  it('appears/disappears as the store mode changes', () => {
+    useIterationStore.setState({ mode: 'stateful', statelessReason: null });
+    const { rerender } = render(<StatelessModeIndicator />);
+    expect(screen.queryByTestId('stateless-indicator')).toBeNull();
+
+    useIterationStore.setState({ mode: 'stateless', statelessReason: 'no-artifact' });
+    rerender(<StatelessModeIndicator />);
+    expect(screen.getByTestId('stateless-indicator')).toHaveTextContent(/stateless/i);
+  });
+});
+```
+
+**Step 2: Run it**
+
+Run: `npm run test -- StatelessModeIndicator.integration`
+Expected: PASS.
+
+**Step 3: Commit**
+
+```bash
+git add src/features/iterations/components/StatelessModeIndicator.integration.test.tsx
+git commit -m "test(iterations): integration coverage for stateless indicator mode transitions"
+```
+
+---
+
+## Task 6: E2E (mock mode)
+
+**Files:**
+- Create: `e2e/mock/stateless-mode/stateless-indicator.spec.ts`
+
+> The directory is for mock-only stateless tests. Use the centralized GitHub mocks in `e2e/fixtures/github-mocks.ts`. The default mock PR (no CodjiFlo artifact comment) lands in stateless mode → `no-artifact` reason. ONE top-level `test.describe` per file (enforced). Each test must complete in < 5s; run with a 1-minute Bash timeout.
+
+**Step 1: Inspect a sibling spec** to copy the navigation/auth fixture pattern (e.g. an existing file under `e2e/mock/stateless-mode/` or `e2e/common/stateless-mode/`). Match how they open a PR and assert on the diff header.
+
+**Step 2: Write the test** — open a stateless-mode PR, assert the indicator is visible with the info copy:
+
+```ts
+import { test, expect } from '@playwright/test';
+// + the project's standard mock setup imports used by sibling specs
+
+test.describe('Stateless-mode indicator', () => {
+  test('shows the stateless pill when no CodjiFlo artifact is present', async ({ page }) => {
+    // navigate to a mock PR the same way sibling specs do
+    const indicator = page.getByTestId('stateless-indicator');
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText(/stateless/i);
+  });
+});
+```
+
+**Step 3: Run it (1-minute timeout)**
+
+Run: `npm run test:e2e -- stateless-indicator`
+Expected: PASS. If it fails, fetch `trace.zip` and run `npx playwright-trace-llm <trace.zip> -o ./trace-export` — do NOT add `waitForTimeout`.
+
+**Step 4: Commit**
+
+```bash
+git add e2e/mock/stateless-mode/stateless-indicator.spec.ts
+git commit -m "test(e2e): stateless-mode indicator visible for artifact-less PR"
+```
+
+---
+
+## Task 7: Full suite + manual sanity check
+
+**Step 1: Run the full required suite**
+
+Run: `npm run test:all`
+Expected: PASS (lint + typecheck + spec:validate + coverage + e2e + storybook).
+
+**Step 2: Manual sanity check** with the playwright-cli skill (headed): open a PR known to be stateless (no artifact) and confirm the pill renders next to the iteration tabs with a working tooltip; if you can reach an unauthenticated state, confirm the sign-in variant.
+
+**Step 3: Push & open PR** (auto-merge per the user's workflow), then monitor the PR lifecycle with a single Monitor call.
+
+---
+
+## Notes / non-goals
+
+- No indicator in stateful mode (renders `null`).
+- No backwards-compat shim for the old free-text `statelessReason` — Explore confirmed nothing displays it today.
+- Mode detection logic itself is unchanged; only the reason's type and its surfacing change.
+- The duplicate `IterationMode` declaration (store-local vs `types.ts`) is left as-is to keep scope tight; not introduced by this change.

--- a/e2e/mock/stateless-mode/stateless-indicator.spec.ts
+++ b/e2e/mock/stateless-mode/stateless-indicator.spec.ts
@@ -1,0 +1,172 @@
+import { test, expect } from "@playwright/test";
+import {
+  setupAuthMock,
+  setupAuthState,
+  setupFullPRMocks,
+  type MockPR,
+  type MockFile,
+} from "../../fixtures/github-mocks";
+import { setupLegacyDefaults } from "../../fixtures/legacy-defaults";
+
+const owner = "test";
+const repo = "repo";
+const prNumber = 123;
+const pageUrl = "/test/repo/123";
+
+const mockPR: MockPR = {
+  id: 1,
+  number: prNumber,
+  title: "Stateless indicator PR",
+  body: "Body",
+  state: "open",
+  merged: false,
+  draft: false,
+  user: {
+    id: 1,
+    login: "testuser",
+    avatar_url: "https://avatars.githubusercontent.com/u/1",
+  },
+  head: { ref: "feature/test", sha: "abc123" },
+  base: { ref: "main", sha: "def456" },
+  html_url: "https://github.com/test/repo/pull/123",
+  created_at: "2024-01-01T10:00:00Z",
+  updated_at: "2024-01-02T15:00:00Z",
+};
+
+const mockFiles: MockFile[] = [
+  {
+    filename: "src/test.ts",
+    status: "modified",
+    additions: 10,
+    deletions: 5,
+    changes: 15,
+    patch: "@@ -1,5 +1,10 @@\n+// New code\n const x = 1;",
+  },
+];
+
+/**
+ * Inject a PR comment carrying the CodjiFlo artifact reference marker, while
+ * making the artifact ZIP download fail. This is the real-world "unauthenticated"
+ * stateless path: an artifact reference EXISTS (so data is available once signed
+ * in) but the anonymous session cannot download it -> statelessReason
+ * 'unauthenticated'. Overrides the empty issues-comments route from
+ * setupFullPRMocks (Playwright routes are LIFO).
+ */
+async function injectArtifactReferenceWithFailedDownload(page: import("@playwright/test").Page) {
+  const artifactId = 987654321;
+  await page.route(
+    `https://api.github.com/repos/${owner}/${repo}/issues/${String(prNumber)}/comments`,
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: 999999,
+            body: `<!-- codjiflo-data -->
+### CodjiFlo Iteration Tracking
+**Iterations captured**: 3
+**Last updated**: 2024-01-02T10:00:00Z
+**Artifact**: \`${String(artifactId)}\`
+**Run ID**: 12345678`,
+            user: { login: "github-actions[bot]", id: 41898282 },
+            created_at: "2024-01-02T10:00:00Z",
+            updated_at: "2024-01-02T10:00:00Z",
+          },
+        ]),
+      });
+    }
+  );
+  // Anonymous artifact download is rejected -> loader.load() resolves null.
+  await page.route(/actions\/artifacts\/.*\/zip/, async (route) => {
+    await route.fulfill({
+      status: 403,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "Must be authenticated" }),
+    });
+  });
+}
+
+test.describe("Stateless-mode indicator", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupLegacyDefaults(page);
+  });
+
+  test("no-artifact: signed-in PR with no CodjiFlo artifact shows the neutral info pill, not a sign-in action", async ({
+    page,
+  }) => {
+    await setupAuthState(page);
+    await setupFullPRMocks(page, owner, repo, prNumber, {
+      pr: mockPR,
+      files: mockFiles,
+    });
+
+    await page.goto(pageUrl);
+
+    const indicator = page.getByTestId("stateless-indicator");
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText(/stateless/i);
+    await expect(indicator).toHaveClass(/stateless-indicator--info/);
+    // Adversarial: a lazy impl that always renders the sign-in variant must fail.
+    await expect(indicator).not.toHaveClass(/stateless-indicator--action/);
+    await expect(indicator).not.toContainText(/sign in/i);
+
+    // It is placed beside the iteration tabs, inside the diff header iterations row.
+    const headerRow = page.getByTestId("diff-header-iterations").first();
+    await expect(headerRow.getByTestId("stateless-indicator")).toBeVisible();
+  });
+
+  test("unauthenticated: signed-out PR with an artifact reference shows the sign-in action pill", async ({
+    page,
+  }) => {
+    // Signed out: setupAuthMock validates a token IF present, but we never call
+    // setupAuthState, so the auth store has no token (real anonymous session).
+    await setupAuthMock(page);
+    await setupFullPRMocks(page, owner, repo, prNumber, {
+      pr: mockPR,
+      files: mockFiles,
+    });
+    await injectArtifactReferenceWithFailedDownload(page);
+
+    await page.goto(pageUrl);
+
+    const indicator = page.getByTestId("stateless-indicator");
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText(/sign in/i);
+    await expect(indicator).toHaveClass(/stateless-indicator--action/);
+    await expect(indicator).not.toHaveClass(/stateless-indicator--info/);
+  });
+
+  test("unauthenticated: pressing the sign-in pill starts the GitHub OAuth flow", async ({
+    page,
+  }) => {
+    await setupAuthMock(page);
+    await setupFullPRMocks(page, owner, repo, prNumber, {
+      pr: mockPR,
+      files: mockFiles,
+    });
+    await injectArtifactReferenceWithFailedDownload(page);
+
+    // Intercept the GitHub OAuth redirect so the click proves initiateOAuth ran
+    // through a real user action (not a stub) without actually leaving to github.com.
+    let oauthRequested = false;
+    await page.route(
+      "https://github.com/login/oauth/authorize**",
+      async (route) => {
+        oauthRequested = true;
+        await route.abort();
+      }
+    );
+
+    await page.goto(pageUrl);
+
+    const indicator = page.getByTestId("stateless-indicator");
+    await expect(indicator).toContainText(/sign in/i);
+
+    await indicator.click();
+
+    await expect
+      .poll(() => oauthRequested, { message: "expected GitHub OAuth redirect" })
+      .toBe(true);
+  });
+});

--- a/src/features/diff/components/DiffView.tsx
+++ b/src/features/diff/components/DiffView.tsx
@@ -32,7 +32,7 @@ import { useCommentsStore, useCommentTracking, type ReviewThread } from '@/featu
 import { usePRStore } from '@/features/pr';
 import type { VisibleRowRange } from '../types';
 import { PRDescription, PRMetadata } from '@/features/pr/components';
-import { IterationSelector } from '@/features/iterations';
+import { IterationSelector, StatelessModeIndicator } from '@/features/iterations';
 
 /** Duration in milliseconds for screen reader announcements */
 const ANNOUNCEMENT_TIMEOUT_MS = 4000;
@@ -205,6 +205,7 @@ export function DiffView() {
       <div className="diff-description-view">
         <div className="diff-header-iterations" data-testid="diff-header-iterations">
           <IterationSelector />
+          <StatelessModeIndicator />
         </div>
         {currentPR ? (
           <>
@@ -241,6 +242,7 @@ export function DiffView() {
       <div className="diff-header" data-testid="diff-header">
         <div className="diff-header-iterations" data-testid="diff-header-iterations">
           <IterationSelector />
+          <StatelessModeIndicator />
         </div>
         <div className="diff-header-toolbar">
           <h2 className="diff-filename" title={pipeline.filename}>

--- a/src/features/diff/hooks/useIterationAwareFiles.integration.test.ts
+++ b/src/features/diff/hooks/useIterationAwareFiles.integration.test.ts
@@ -11,7 +11,7 @@ import { useIterationAwareFiles } from './useIterationAwareFiles';
 import { useDiffStore } from '../stores';
 import { FileChangeStatus } from '@/api/types';
 import type { FileChange } from '@/api/types';
-import type { ReviewFileArtifact, FileContent } from '@/features/iterations/types';
+import type { ReviewFileArtifact, FileContent, StatelessReason } from '@/features/iterations/types';
 
 // Mock dependencies
 vi.mock('../stores', () => ({
@@ -22,7 +22,7 @@ vi.mock('../stores', () => ({
 interface MockIterationStoreState {
   client: MockIterationClient | null;
   mode: 'stateful' | 'stateless';
-  statelessReason?: string | null;
+  statelessReason?: StatelessReason | null;
   artifacts: ReviewFileArtifact[];
   selectedRange: { fromSnapshot: number; toSnapshot: number } | null;
   currentPrKey?: string | null;
@@ -230,7 +230,7 @@ describe('useIterationAwareFiles - Integration Tests', () => {
         client: null,
         selectedRange: null,
         mode: 'stateless',
-        statelessReason: 'No CodjiFlo artifact found. The repository may not have the CodjiFlo GitHub Action installed.',
+        statelessReason: 'no-artifact',
         artifacts: [],
         currentPrKey: 'https://github.com/test/repo/pull/123',
       };
@@ -253,7 +253,7 @@ describe('useIterationAwareFiles - Integration Tests', () => {
       expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
       expect(consoleWarnSpy).toHaveBeenCalledWith(
         '[CodjiFlo] Using GitHub API as fallback (stateless mode). ' +
-        'Reason: No CodjiFlo artifact found. The repository may not have the CodjiFlo GitHub Action installed.. ' +
+        'Reason: No CodjiFlo artifact found (the repository may not have the CodjiFlo GitHub Action installed). ' +
         'Iteration tracking features are unavailable.'
       );
 
@@ -268,7 +268,7 @@ describe('useIterationAwareFiles - Integration Tests', () => {
         client: null,
         selectedRange: null,
         mode: 'stateless',
-        statelessReason: 'Test reason',
+        statelessReason: 'no-artifact',
         artifacts: [],
         currentPrKey: 'https://github.com/test/repo/pull/123',
       };
@@ -305,7 +305,7 @@ describe('useIterationAwareFiles - Integration Tests', () => {
         client: null,
         selectedRange: null,
         mode: 'stateless',
-        statelessReason: 'Test reason',
+        statelessReason: 'no-artifact',
         artifacts: [],
         currentPrKey: 'https://github.com/test/repo/pull/123',
       };

--- a/src/features/diff/hooks/useIterationAwareFiles.ts
+++ b/src/features/diff/hooks/useIterationAwareFiles.ts
@@ -17,7 +17,19 @@ import { useIterationStore } from '@/features/iterations/stores';
 import type { FileChange } from '@/api/types';
 import { FileChangeStatus } from '@/api/types';
 import type { ParsedDiffLine } from '../types';
-import type { ReviewFileArtifact } from '@/features/iterations/types';
+import type { ReviewFileArtifact, StatelessReason } from '@/features/iterations/types';
+
+/**
+ * Human-readable text for each stateless reason, used when surfacing the
+ * fallback warning. The store keeps the canonical enum; presentation maps it
+ * here (mirroring how StatelessModeIndicator maps the enum to tooltip copy).
+ */
+const STATELESS_REASON_DESCRIPTION: { [reason in StatelessReason]: string } = {
+  'no-artifact':
+    'No CodjiFlo artifact found (the repository may not have the CodjiFlo GitHub Action installed)',
+  unauthenticated:
+    'Sign in to enable iteration tracking — CodjiFlo data is available for this PR',
+};
 
 export interface IterationAwareFile extends FileChange {
   /** Original GitHub index for file selection */
@@ -60,9 +72,12 @@ export function useIterationAwareFiles(): IterationAwareFilesResult {
     // Only warn if we're in stateless mode and haven't warned for this PR yet
     if (mode === 'stateless' && currentPrKey && warnedForPrRef.current !== currentPrKey) {
       warnedForPrRef.current = currentPrKey;
+      const reasonText = statelessReason
+        ? STATELESS_REASON_DESCRIPTION[statelessReason]
+        : 'Unknown';
       console.warn(
         `[CodjiFlo] Using GitHub API as fallback (stateless mode). ` +
-        `Reason: ${statelessReason ?? 'Unknown'}. ` +
+        `Reason: ${reasonText}. ` +
         `Iteration tracking features are unavailable.`
       );
     }

--- a/src/features/iterations/components/StatelessModeIndicator.integration.test.tsx
+++ b/src/features/iterations/components/StatelessModeIndicator.integration.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { StatelessModeIndicator } from './StatelessModeIndicator';
+import { useIterationStore } from '../stores';
+
+// useOAuthFlow is an external dependency (it redirects the browser to GitHub),
+// not the system under test. Stub it so the action pill can mount without a real
+// redirect, while keeping a stable spy so we can assert the login flow is
+// initiated by a real user press. The hoisted spy survives re-renders (an inline
+// vi.fn() in the factory would be recreated each render and lose call history).
+const mockInitiateOAuth = vi.hoisted(() => vi.fn());
+vi.mock('@/features/auth/hooks', () => ({
+  useOAuthFlow: () => ({
+    initiateOAuth: mockInitiateOAuth,
+    isInitiating: false,
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+/**
+ * Drive the REAL store the same way loadIterations does in production:
+ * by setting `mode` + `statelessReason`. The rendered pill is then asserted
+ * as a user would see it. No module-level store mock, no test-only backdoor.
+ */
+function setStoreMode(
+  mode: 'stateful' | 'stateless',
+  statelessReason: 'unauthenticated' | 'no-artifact' | null,
+) {
+  act(() => {
+    useIterationStore.setState({ mode, statelessReason });
+  });
+}
+
+describe('StatelessModeIndicator (integration)', () => {
+  beforeEach(() => {
+    mockInitiateOAuth.mockClear();
+    act(() => {
+      useIterationStore.getState().reset();
+    });
+  });
+
+  it('shows nothing initially (default stateful store), then appears and disappears as the live store mode changes', () => {
+    // Initial state from reset() is stateful -> nothing rendered.
+    render(<StatelessModeIndicator />);
+    expect(screen.queryByTestId('stateless-indicator')).toBeNull();
+
+    // Production transition into stateless/no-artifact: pill must appear via a
+    // live store subscription (NOT a rerender prop) with the info variant.
+    setStoreMode('stateless', 'no-artifact');
+    const infoPill = screen.getByTestId('stateless-indicator');
+    expect(infoPill).toHaveTextContent(/stateless/i);
+    expect(infoPill).toHaveClass('stateless-indicator--info');
+    expect(infoPill).not.toHaveClass('stateless-indicator--action');
+
+    // Transition back to stateful: the pill must UNMOUNT, not linger.
+    // Catches an impl that renders once and never reacts to mode going back.
+    setStoreMode('stateful', null);
+    expect(screen.queryByTestId('stateless-indicator')).toBeNull();
+  });
+
+  it('switches between the info and action variants when only statelessReason changes', () => {
+    render(<StatelessModeIndicator />);
+
+    // no-artifact -> neutral info pill, text "Stateless", no sign-in copy.
+    setStoreMode('stateless', 'no-artifact');
+    const infoPill = screen.getByTestId('stateless-indicator');
+    expect(infoPill).toHaveTextContent(/stateless/i);
+    expect(infoPill).not.toHaveTextContent(/sign in/i);
+    expect(infoPill).toHaveClass('stateless-indicator--info');
+
+    // unauthenticated -> actionable sign-in pill. The variant (class + copy)
+    // must flip purely from statelessReason while mode stays 'stateless'.
+    // A lazy impl that branches only on `mode` would fail this.
+    setStoreMode('stateless', 'unauthenticated');
+    const actionPill = screen.getByTestId('stateless-indicator');
+    expect(actionPill).toHaveTextContent(/sign in/i);
+    expect(actionPill).toHaveClass('stateless-indicator--action');
+    expect(actionPill).not.toHaveClass('stateless-indicator--info');
+  });
+
+  it('renders the action variant as an interactive element with an accessible name (not colour-only)', () => {
+    setStoreMode('stateless', 'unauthenticated');
+    render(<StatelessModeIndicator />);
+
+    // State must be conveyed without relying on colour: the pill exposes an
+    // accessible name. We assert a real accessible role/name, not just a div.
+    const pill = screen.getByTestId('stateless-indicator');
+    expect(pill).toHaveAccessibleName(/sign in|stateless/i);
+  });
+
+  it('initiates the OAuth login flow when the user presses the sign-in (unauthenticated) pill', async () => {
+    const user = userEvent.setup();
+    setStoreMode('stateless', 'unauthenticated');
+    render(<StatelessModeIndicator />);
+
+    await user.click(screen.getByTestId('stateless-indicator'));
+    expect(mockInitiateOAuth).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT initiate OAuth when the user presses the neutral no-artifact info pill', async () => {
+    // Adversarial: a lazy impl that wires the same onPress on both variants
+    // would wrongly trigger a login redirect from the informational pill.
+    const user = userEvent.setup();
+    setStoreMode('stateless', 'no-artifact');
+    render(<StatelessModeIndicator />);
+
+    await user.click(screen.getByTestId('stateless-indicator'));
+    expect(mockInitiateOAuth).not.toHaveBeenCalled();
+  });
+});

--- a/src/features/iterations/components/StatelessModeIndicator.test.tsx
+++ b/src/features/iterations/components/StatelessModeIndicator.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StatelessModeIndicator } from './StatelessModeIndicator';
+import { useIterationStore } from '../stores';
+
+const mockInitiateOAuth = vi.fn();
+vi.mock('@/features/auth/hooks', () => ({
+  useOAuthFlow: () => ({
+    initiateOAuth: mockInitiateOAuth,
+    isInitiating: false,
+    error: null,
+    clearError: vi.fn(),
+  }),
+}));
+
+function setMode(
+  mode: 'stateful' | 'stateless',
+  statelessReason: 'unauthenticated' | 'no-artifact' | null,
+) {
+  useIterationStore.setState({ mode, statelessReason });
+}
+
+describe('StatelessModeIndicator', () => {
+  beforeEach(() => {
+    mockInitiateOAuth.mockClear();
+    useIterationStore.getState().reset();
+  });
+
+  it('renders nothing in stateful mode', () => {
+    setMode('stateful', null);
+    const { container } = render(<StatelessModeIndicator />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a neutral info pill when the repo has no artifact', () => {
+    setMode('stateless', 'no-artifact');
+    render(<StatelessModeIndicator />);
+    const pill = screen.getByTestId('stateless-indicator');
+    expect(pill).toHaveTextContent(/stateless/i);
+    expect(pill).toHaveClass('stateless-indicator--info');
+  });
+
+  it('renders a sign-in action pill when unauthenticated', () => {
+    setMode('stateless', 'unauthenticated');
+    render(<StatelessModeIndicator />);
+    const pill = screen.getByTestId('stateless-indicator');
+    expect(pill).toHaveTextContent(/sign in/i);
+    expect(pill).toHaveClass('stateless-indicator--action');
+  });
+
+  it('initiates OAuth when the sign-in pill is pressed', async () => {
+    setMode('stateless', 'unauthenticated');
+    render(<StatelessModeIndicator />);
+    await userEvent.click(screen.getByTestId('stateless-indicator'));
+    expect(mockInitiateOAuth).toHaveBeenCalledOnce();
+  });
+});

--- a/src/features/iterations/components/StatelessModeIndicator.tsx
+++ b/src/features/iterations/components/StatelessModeIndicator.tsx
@@ -1,0 +1,60 @@
+import { Zap, LogIn } from 'lucide-react';
+import { Button } from '@/components';
+import { TooltipTrigger, Tooltip } from '@/components/ui';
+import { useOAuthFlow } from '@/features/auth/hooks';
+import { useIterationStore } from '../stores';
+
+const NO_ARTIFACT_TOOLTIP =
+  'No CodjiFlo artifact found. This repo may not have the CodjiFlo GitHub Action installed. Iteration tracking is limited.';
+const UNAUTHENTICATED_TOOLTIP =
+  'CodjiFlo data is available for this PR. Sign in to enable full iteration tracking.';
+
+/**
+ * Compact pill shown next to the iteration tabs when iteration data is in
+ * stateless mode. Renders nothing in stateful mode, a neutral info pill when
+ * the repo has no CodjiFlo artifact, or an actionable sign-in pill when the
+ * cause is an anonymous session.
+ */
+export function StatelessModeIndicator() {
+  const mode = useIterationStore((s) => s.mode);
+  const statelessReason = useIterationStore((s) => s.statelessReason);
+  const { initiateOAuth } = useOAuthFlow();
+
+  if (mode === 'stateful') {
+    return null;
+  }
+
+  if (statelessReason === 'unauthenticated') {
+    return (
+      <TooltipTrigger>
+        <Button
+          className="stateless-indicator stateless-indicator--action"
+          data-testid="stateless-indicator"
+          onPress={() => { initiateOAuth(); }}
+          aria-label="Stateless mode — sign in to enable full iteration tracking"
+        >
+          <LogIn size={12} aria-hidden="true" />
+          <span>Sign in for full tracking</span>
+        </Button>
+        <Tooltip className="stateless-indicator-tooltip">{UNAUTHENTICATED_TOOLTIP}</Tooltip>
+      </TooltipTrigger>
+    );
+  }
+
+  // statelessReason === 'no-artifact' (and any future stateless reason): neutral info pill.
+  // The Button has no onPress — it is a focusable tooltip trigger only; the
+  // aria-label carries the meaning so state is not conveyed by colour alone.
+  return (
+    <TooltipTrigger>
+      <Button
+        className="stateless-indicator stateless-indicator--info"
+        data-testid="stateless-indicator"
+        aria-label="Stateless mode — iteration tracking is limited"
+      >
+        <Zap size={12} aria-hidden="true" />
+        <span>Stateless</span>
+      </Button>
+      <Tooltip className="stateless-indicator-tooltip">{NO_ARTIFACT_TOOLTIP}</Tooltip>
+    </TooltipTrigger>
+  );
+}

--- a/src/features/iterations/components/index.ts
+++ b/src/features/iterations/components/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { IterationSelector } from './IterationSelector';
+export { StatelessModeIndicator } from './StatelessModeIndicator';

--- a/src/features/iterations/index.ts
+++ b/src/features/iterations/index.ts
@@ -6,7 +6,7 @@
  */
 
 // Components
-export { IterationSelector } from './components';
+export { IterationSelector, StatelessModeIndicator } from './components';
 
 // Store
 export { useIterationStore } from './stores';

--- a/src/features/iterations/stores/useIterationStore.test.ts
+++ b/src/features/iterations/stores/useIterationStore.test.ts
@@ -144,6 +144,10 @@ describe('useIterationStore', () => {
     mockTimelineLoad.mockReset();
     mockGithubClientFetch.mockReset();
 
+    // Reset auth store to signed-out so a test that mutates the token (e.g. the
+    // unauthenticated stateless case) can't bleed into order-dependent siblings.
+    useAuthStore.setState({ token: null });
+
     // Default: findArtifactReference returns the mock reference
     // Tests can override this when needed (e.g., for stateless mode)
     mockFindArtifactReference.mockResolvedValue(createMockReference());
@@ -384,9 +388,9 @@ describe('useIterationStore', () => {
     });
 
     it('should set statelessReason to "unauthenticated" when artifact exists but user is signed out', async () => {
-      // Artifact reference is present (default beforeEach mock), but the user
-      // has no token and the artifact load fails -> "data available once signed in".
-      useAuthStore.setState({ token: null });
+      // Artifact reference is present (default beforeEach mock) and the user is
+      // signed out (token reset to null in beforeEach) while the artifact load
+      // fails -> "data available once signed in".
       mockFindArtifactReference.mockResolvedValue(createMockReference());
       mockLoad.mockResolvedValue(null);
       mockGithubClientFetch.mockResolvedValue({ base: { sha: 'base' } });

--- a/src/features/iterations/stores/useIterationStore.test.ts
+++ b/src/features/iterations/stores/useIterationStore.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { useIterationStore, selectSelectedRange } from './useIterationStore';
+import { useAuthStore } from '@/features/auth/stores/useAuthStore';
 import type { Iteration, ReviewFileArtifact, ArtifactReference } from '../types';
 
 // Create mock implementations that will be controlled by tests
@@ -367,6 +368,7 @@ describe('useIterationStore', () => {
 
       const state = useIterationStore.getState();
       expect(state.mode).toBe('stateless');
+      expect(state.statelessReason).toBe('no-artifact');
       expect(state.iterations).toHaveLength(2);
       expect(state.iterations[0]).toMatchObject({ headSha: 'commit-sha-1' });
       expect(state.iterations[1]).toMatchObject({ headSha: 'commit-sha-2' });
@@ -379,6 +381,22 @@ describe('useIterationStore', () => {
         fromSnapshot: 2,
         toSnapshot: 3,
       });
+    });
+
+    it('should set statelessReason to "unauthenticated" when artifact exists but user is signed out', async () => {
+      // Artifact reference is present (default beforeEach mock), but the user
+      // has no token and the artifact load fails -> "data available once signed in".
+      useAuthStore.setState({ token: null });
+      mockFindArtifactReference.mockResolvedValue(createMockReference());
+      mockLoad.mockResolvedValue(null);
+      mockGithubClientFetch.mockResolvedValue({ base: { sha: 'base' } });
+      mockTimelineLoad.mockResolvedValue({ iterations: [], collapsedGroups: [] });
+
+      await useIterationStore.getState().loadIterations('owner', 'repo', 1);
+
+      const state = useIterationStore.getState();
+      expect(state.mode).toBe('stateless');
+      expect(state.statelessReason).toBe('unauthenticated');
     });
 
     it('should store collapsed groups from TimelineLoader', async () => {

--- a/src/features/iterations/stores/useIterationStore.ts
+++ b/src/features/iterations/stores/useIterationStore.ts
@@ -21,6 +21,7 @@ import type {
   IterationPreset,
   ArtifactReference,
   CollapsedIterationGroup,
+  StatelessReason,
 } from '../types';
 import { iterationToLeftSnapshot, iterationToRightSnapshot } from '../types';
 
@@ -83,8 +84,8 @@ interface IterationState {
   error: string | null;
   /** Iteration storage mode: 'stateful' when artifact is available, 'stateless' for GitHub API only */
   mode: IterationMode;
-  /** Reason for stateless mode (for debugging, null when stateful) */
-  statelessReason: string | null;
+  /** Reason for stateless mode (null when stateful) */
+  statelessReason: StatelessReason | null;
 
   // Actions
   loadIterations: (owner: string, repo: string, prNumber: number) => Promise<void>;
@@ -151,12 +152,12 @@ export const useIterationStore = create<IterationState>()(
             const hasArtifactReference = earlyReference !== null;
             const isAuthenticated = useAuthStore.getState().token !== null;
 
-            let reason: string;
+            let reason: StatelessReason;
             if (hasArtifactReference && !isAuthenticated) {
-              reason = 'Sign in to enable iteration tracking. CodjiFlo data is available for this PR.';
+              reason = 'unauthenticated';
               console.info(`[CodjiFlo] Entering stateless mode: not authenticated for ${prKey}`);
             } else {
-              reason = 'No CodjiFlo artifact found. The repository may not have the CodjiFlo GitHub Action installed.';
+              reason = 'no-artifact';
               console.info(`[CodjiFlo] Entering stateless mode: no artifact found for ${prKey}`);
             }
 

--- a/src/features/iterations/types.ts
+++ b/src/features/iterations/types.ts
@@ -174,6 +174,13 @@ export interface ArtifactReference {
 /** Iteration storage mode: stateful (artifact available) or stateless (GitHub API only) */
 export type IterationMode = 'stateful' | 'stateless';
 
+/**
+ * Why iteration data is in stateless mode.
+ * - 'unauthenticated': a CodjiFlo artifact exists but the user is signed out (data available once signed in)
+ * - 'no-artifact': no CodjiFlo artifact found (repo likely lacks the CodjiFlo GitHub Action)
+ */
+export type StatelessReason = 'unauthenticated' | 'no-artifact';
+
 export interface IterationState {
   /** All iterations loaded from artifact */
   iterations: Iteration[];
@@ -202,8 +209,8 @@ export interface IterationState {
   /** Iteration storage mode: 'stateful' when artifact is available, 'stateless' for GitHub API only */
   mode: IterationMode;
 
-  /** Reason for stateless mode (for debugging, null when stateful) */
-  statelessReason: string | null;
+  /** Reason for stateless mode (null when stateful) */
+  statelessReason: StatelessReason | null;
 
   // Actions
   loadIterations: (owner: string, repo: string, prNumber: number) => Promise<void>;

--- a/src/styles/shared/features.css
+++ b/src/styles/shared/features.css
@@ -937,3 +937,51 @@
   stroke: #505050;
   stroke-width: 2;
 }
+
+/* ============================================
+   STATELESS-MODE INDICATOR
+   ============================================ */
+/* Compact pill next to the iteration tabs surfacing stateless mode. */
+.stateless-indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: none;
+  border-radius: 10px;
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: nowrap;
+  cursor: default;
+}
+
+.stateless-indicator--info {
+  background-color: var(--badge-merged);
+  color: white;
+}
+
+.stateless-indicator--action {
+  background-color: var(--error-fg);
+  color: white;
+  cursor: pointer;
+}
+
+.stateless-indicator--action[data-hovered],
+.stateless-indicator--action[data-focus-visible] {
+  filter: brightness(1.1);
+  outline: 2px solid var(--focus-border);
+  outline-offset: 1px;
+}
+
+/* Matches the .field-tip react-aria Tooltip pattern in controls.css so the
+   surface is solid and readable across every theme. */
+.stateless-indicator-tooltip {
+  max-width: 260px;
+  padding: 6px 10px;
+  border: 1px solid var(--combobox-border);
+  border-radius: 4px;
+  font-size: 11px;
+  background-color: var(--contextmenu-bg);
+  color: var(--main-fg);
+  z-index: 1000;
+}

--- a/src/styles/shared/features.css
+++ b/src/styles/shared/features.css
@@ -521,6 +521,7 @@
   display: flex;
   align-items: center;
   justify-content: flex-start;
+  gap: 8px;
   padding: 0;
   background-color: var(--listview-header);
 }


### PR DESCRIPTION
## Summary
- Adds a `StatelessModeIndicator` pill next to the iteration tabs so reviewers can see at a glance when a PR's iteration data is in **stateless mode** (the GitHub Timeline-API fallback) rather than the full GitHub-Action artifact mode.
- Two variants: a neutral **"Stateless"** info pill when the repo has no CodjiFlo artifact, and an actionable **"Sign in for full tracking"** pill (wired to the OAuth flow) when data exists but the viewer is signed out.
- Narrows the store's `statelessReason` from a free-text `string` to a typed `StatelessReason = 'unauthenticated' | 'no-artifact'` enum, and maps that enum to human-readable copy at each presentation point (tooltip + the existing fallback console warning).

## Details
- `StatelessModeIndicator` is built from react-aria `Button` + `Tooltip`, lucide icons, with an `aria-label` so state isn't conveyed by colour alone. Rendered as a sibling of `<IterationSelector />` in both `.diff-header-iterations` blocks; returns `null` in stateful mode.
- A second consumer of `statelessReason` (`useIterationAwareFiles` fallback warning) is updated to map the enum to a human sentence, preserving the Issue #186 warning contract.

## Test Plan
- [x] `npm run test:all` green: lint, typecheck, spec:validate (11), vitest+coverage (1544), E2E (124), storybook (31)
- [x] New unit tests (component), 5 integration tests (full state matrix incl. negative cases), 3 E2E tests (no-artifact info pill, unauthenticated action pill, sign-in click triggers the real GitHub OAuth redirect)
- [x] Manual headed Playwright check: info pill renders cleanly in the diff header on a real stateless PR; live console confirms the mapped human-readable fallback warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- codjiflo-link -->

---

🔍 **[Review in CodjiFlo](https://codjiflo.net/vezzadev/codjiflo/545)**

<!-- codjiflo-link -->